### PR TITLE
Fix event subscription for pydantic v1

### DIFF
--- a/ai_inference_service.py
+++ b/ai_inference_service.py
@@ -84,7 +84,7 @@ class AIInferenceService:
 
     async def run(self):
         print("AIInferenceService: Starting...")
-        self.bus.subscribe(AIInferenceRequestEvent.model_fields['event_type'].default, self._handle_inference_request)
+        self.bus.subscribe(AIInferenceRequestEvent.get_event_type(), self._handle_inference_request)
         await self._stop_event.wait() # Keep running until stop is called
         print("AIInferenceService: Stopped.")
 

--- a/event_definitions.py
+++ b/event_definitions.py
@@ -7,6 +7,13 @@ class BaseEvent(BaseModel):
     event_type: str = Field(..., description="The type of the event")
     timestamp: float = Field(default_factory=time.time, description="Event creation timestamp")
 
+    @classmethod
+    def get_event_type(cls) -> str:
+        """Return the default event type for this class."""
+        if hasattr(cls, "model_fields"):
+            return cls.model_fields["event_type"].default  # type: ignore[attr-defined]
+        return cls.__fields__["event_type"].default  # type: ignore[attr-defined]
+
 class MatrixMessageReceivedEvent(BaseEvent):
     event_type: str = "matrix_message_received"
     room_id: str

--- a/matrix_gateway_service.py
+++ b/matrix_gateway_service.py
@@ -66,7 +66,7 @@ class MatrixGatewayService:
 
         self.client = AsyncClient(self.homeserver, self.user_id)
         self.client.add_event_callback(self._matrix_message_callback, RoomMessageText)
-        self.bus.subscribe(SendMatrixMessageCommand.model_fields['event_type'].default, self._handle_send_message_command)
+        self.bus.subscribe(SendMatrixMessageCommand.get_event_type(), self._handle_send_message_command)
 
         try:
             print(f"Gateway: Attempting login as {self.user_id}...")

--- a/room_logic_service.py
+++ b/room_logic_service.py
@@ -252,10 +252,10 @@ class RoomLogicService:
 
     async def run(self):
         print("RoomLogicService: Starting...")
-        self.bus.subscribe(BotDisplayNameReadyEvent.model_fields['event_type'].default, self._handle_bot_display_name_ready)
-        self.bus.subscribe(MatrixMessageReceivedEvent.model_fields['event_type'].default, self._handle_matrix_message)
-        self.bus.subscribe(ActivateListeningEvent.model_fields['event_type'].default, self._handle_activate_listening)
-        self.bus.subscribe(ProcessMessageBatchCommand.model_fields['event_type'].default, self._handle_process_message_batch)
+        self.bus.subscribe(BotDisplayNameReadyEvent.get_event_type(), self._handle_bot_display_name_ready)
+        self.bus.subscribe(MatrixMessageReceivedEvent.get_event_type(), self._handle_matrix_message)
+        self.bus.subscribe(ActivateListeningEvent.get_event_type(), self._handle_activate_listening)
+        self.bus.subscribe(ProcessMessageBatchCommand.get_event_type(), self._handle_process_message_batch)
         # For AI responses specific to chat
         self.bus.subscribe("ai_chat_response_received", self._handle_ai_chat_response) 
         

--- a/summarization_service.py
+++ b/summarization_service.py
@@ -98,7 +98,7 @@ class SummarizationService:
 
     async def run(self):
         print("SummarizationService: Starting...")
-        self.bus.subscribe(BotDisplayNameReadyEvent.model_fields['event_type'].default, self._handle_bot_display_name_ready)
+        self.bus.subscribe(BotDisplayNameReadyEvent.get_event_type(), self._handle_bot_display_name_ready)
         # This service listens for AIInferenceResponseEvents that were intended for it (summary results)
         self.bus.subscribe("ai_summary_response_received", self._handle_ai_summary_response)
         # GenerateSummaryRequestEvent is now handled by RoomLogicService, which then makes an AIInferenceRequest.


### PR DESCRIPTION
## Summary
- add `BaseEvent.get_event_type` helper for Pydantic v1/v2 compatibility
- use the helper when subscribing to events in all services

## Testing
- `python -m py_compile $(git ls-files '*.py')`