### PR TITLE
Apply async DB fixes and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/room_logic_service.py
+++ b/room_logic_service.py
@@ -150,7 +150,7 @@ class RoomLogicService:
             config['batch_response_task'].cancel() # Cancel any pending batch from previous active period
 
         if not config:
-            db_summary_info = database.get_summary(self.db_path, room_id) # Added self.db_path
+            db_summary_info = await asyncio.to_thread(database.get_summary, self.db_path, room_id)  # non-blocking
             initial_last_event_id_db = db_summary_info[1] if db_summary_info else None
 
             config = {
@@ -270,7 +270,7 @@ class RoomLogicService:
         await self.bus.publish(SetTypingIndicatorCommand(room_id=room_id, typing=True))
 
         short_term_memory = config.get('memory', [])
-        summary_text_for_prompt, _ = database.get_summary(self.db_path, room_id) or (None, None)
+        summary_text_for_prompt, _ = await asyncio.to_thread(database.get_summary, self.db_path, room_id) or (None, None)
 
         last_user_event_id_in_batch = None
         # Convert BatchedUserMessage back to the dict format expected by build_messages_for_ai
@@ -562,7 +562,7 @@ class RoomLogicService:
             summary_text = response_event.text_response
             if summary_text:
                 last_event_id_in_summary = config['memory'][-1]["event_id"] if config['memory'] else None
-                database.store_summary(self.db_path, room_id, summary_text, last_event_id_in_summary)
+                await asyncio.to_thread(database.update_summary, self.db_path, room_id, summary_text, last_event_id_in_summary)
                 config['new_turns_since_last_summary'] = 0
                 logger.info(f"RLS: [{room_id}] Summary stored successfully.")
             else:
@@ -728,7 +728,7 @@ class RoomLogicService:
         # Now, prepare and publish the follow-up AI request using augmented_history_for_follow_up
         original_ai_payload_from_first_call = pending_turn_info["original_ai_response_payload"]
         current_user_ids_in_context = original_ai_payload_from_first_call.get("current_user_ids_in_context", [])
-        current_channel_summary, _ = database.get_summary(self.db_path, room_id) or (None, None)
+        current_channel_summary, _ = await asyncio.to_thread(database.get_summary, self.db_path, room_id) or (None, None)
 
         follow_up_payload = prompt_constructor.build_messages_for_ai(
             historical_messages=augmented_history_for_follow_up,  # Use the history built in this block

--- a/summarization_service.py
+++ b/summarization_service.py
@@ -48,7 +48,7 @@ class SummarizationService:
             return
         if response_event.success and response_event.text_response and response_event.text_response.strip():
             summary_text = response_event.text_response
-            database.update_summary(self.db_path, room_id, summary_text, event_id_last_msg)
+            await asyncio.to_thread(database.update_summary, self.db_path, room_id, summary_text, event_id_last_msg)
             logger.info(f"SummarizationSvc: [{room_id}] DB summary updated. Last event: {event_id_last_msg}. Len: {len(summary_text)}")
             await self.bus.publish(SummaryGeneratedEvent(
                 room_id=room_id, 
@@ -71,7 +71,7 @@ class SummarizationService:
             logger.info(f"SummarizationSvc: [{room_id}] No messages to summarize and not a forced update. Skipping.")
             return
 
-        previous_summary_text, _ = database.get_summary(self.db_path, room_id) or (None, None)
+        previous_summary_text, _ = await asyncio.to_thread(database.get_summary, self.db_path, room_id) or (None, None)
         
         # Determine the event_id of the last message in the batch to be summarized
         event_id_of_last_message_in_summary_batch: Optional[str] = None

--- a/tests/unit/test_manage_channel_summary_tool.py
+++ b/tests/unit/test_manage_channel_summary_tool.py
@@ -145,6 +145,6 @@ async def test_manage_channel_summary_tool_execute_missing_action(summary_tool_i
     )
 
     assert result.status == "failure"
-    assert "Missing required argument: action" in result.error_message # Updated expected error message
-    assert result.result_for_llm_history == "[Tool manage_channel_summary failed: Missing required argument 'action']" # Check new llm history message
+    assert "Invalid arguments" in result.result_for_llm_history
+    assert "Invalid arguments" in result.error_message
     assert not result.commands_to_publish

--- a/tests/unit/test_manage_system_prompt_tool.py
+++ b/tests/unit/test_manage_system_prompt_tool.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from available_tools.manage_system_prompt_tool import ManageSystemPromptTool
 from tool_base import ToolResult
@@ -18,9 +18,9 @@ def test_manage_system_prompt_tool_get_definition(manage_system_prompt_tool_inst
     assert "action" in definition["function"]["parameters"]["required"]
 
 @pytest.mark.asyncio
-@patch('available_tools.manage_system_prompt_tool.database', new_callable=AsyncMock) # Mock database module used by the tool
+@patch('available_tools.manage_system_prompt_tool.database', new_callable=MagicMock) # Mock database module used by the tool
 async def test_manage_system_prompt_tool_get_current_success(mock_db, manage_system_prompt_tool_instance: ManageSystemPromptTool):
-    mock_db.get_prompt = AsyncMock(return_value=("Current system prompt", None)) # Simulate DB returning a prompt
+    mock_db.get_prompt = MagicMock(return_value=("Current system prompt", None)) # Simulate DB returning a prompt
     room_id = "!test_room:matrix.org"
     arguments = {"action": "get_current"}
     db_path_param = "dummy_db_path.db"
@@ -36,9 +36,9 @@ async def test_manage_system_prompt_tool_get_current_success(mock_db, manage_sys
     assert not result.commands_to_publish
 
 @pytest.mark.asyncio
-@patch('available_tools.manage_system_prompt_tool.database', new_callable=AsyncMock)
+@patch('available_tools.manage_system_prompt_tool.database', new_callable=MagicMock)
 async def test_manage_system_prompt_tool_get_current_not_found(mock_db, manage_system_prompt_tool_instance: ManageSystemPromptTool):
-    mock_db.get_prompt = AsyncMock(return_value=(None, None)) # Simulate DB returning no prompt
+    mock_db.get_prompt = MagicMock(return_value=(None, None)) # Simulate DB returning no prompt
     arguments = {"action": "get_current"}
     db_path_param = "dummy_db_path.db"
 
@@ -52,9 +52,9 @@ async def test_manage_system_prompt_tool_get_current_not_found(mock_db, manage_s
     mock_db.get_prompt.assert_called_once_with(db_path_param, "system_default")
 
 @pytest.mark.asyncio
-@patch('available_tools.manage_system_prompt_tool.database', new_callable=AsyncMock)
+@patch('available_tools.manage_system_prompt_tool.database', new_callable=MagicMock)
 async def test_manage_system_prompt_tool_update_success(mock_db, manage_system_prompt_tool_instance: ManageSystemPromptTool):
-    mock_db.update_prompt = AsyncMock() # No return value needed for update
+    mock_db.update_prompt = MagicMock() # No return value needed for update
     new_prompt = "This is the new system prompt."
     arguments = {"action": "update", "new_prompt_text": new_prompt}
     db_path_param = "dummy_db_path.db"
@@ -102,7 +102,7 @@ async def test_manage_system_prompt_tool_invalid_action(manage_system_prompt_too
     assert "Invalid action specified: delete. Must be 'get_current' or 'update'." in result.error_message
 
 @pytest.mark.asyncio
-@patch('available_tools.manage_system_prompt_tool.database', new_callable=AsyncMock)
+@patch('available_tools.manage_system_prompt_tool.database', new_callable=MagicMock)
 async def test_manage_system_prompt_tool_db_exception_on_get(mock_db, manage_system_prompt_tool_instance: ManageSystemPromptTool):
     mock_db.get_prompt.side_effect = Exception("DB error on get")
     arguments = {"action": "get_current"}
@@ -117,7 +117,7 @@ async def test_manage_system_prompt_tool_db_exception_on_get(mock_db, manage_sys
     assert "DB error on get" in result.error_message
 
 @pytest.mark.asyncio
-@patch('available_tools.manage_system_prompt_tool.database', new_callable=AsyncMock)
+@patch('available_tools.manage_system_prompt_tool.database', new_callable=MagicMock)
 async def test_manage_system_prompt_tool_db_exception_on_update(mock_db, manage_system_prompt_tool_instance: ManageSystemPromptTool):
     mock_db.update_prompt.side_effect = Exception("DB error on update")
     arguments = {"action": "update", "new_prompt_text": "test"}


### PR DESCRIPTION
## Summary
- make database calls non-blocking with `asyncio.to_thread`
- sanitize tool arguments using Pydantic models
- update CI workflow to use Python 3.10
- adjust tests for new validation logic

## Testing
- `pytest -q`