### PR TITLE
Add EventType enum and update codebase

### DIFF
--- a/ai_inference_service.py
+++ b/ai_inference_service.py
@@ -250,7 +250,7 @@ class AIInferenceService:
     async def run(self) -> None:
         logger.info("AIInferenceService: Starting...")
         # Access default from model_fields for subscription
-        self.bus.subscribe(OpenRouterInferenceRequestEvent.model_fields['event_type'].default, self._handle_inference_request)
+        self.bus.subscribe(OpenRouterInferenceRequestEvent.get_event_type(), self._handle_inference_request)
         await self._stop_event.wait()
         logger.info("AIInferenceService: Stopped.")
 

--- a/matrix_gateway_service.py
+++ b/matrix_gateway_service.py
@@ -398,12 +398,12 @@ class MatrixGatewayService:
         self.client.add_event_callback(self._matrix_message_callback, RoomMessageText)
         self.client.add_event_callback(self._matrix_image_callback, RoomMessageImage)
         # Subscribe to commands
-        self.bus.subscribe(SendMatrixMessageCommand.model_fields['event_type'].default, self._handle_send_message_command)
-        self.bus.subscribe(ReactToMessageCommand.model_fields['event_type'].default, self._handle_react_to_message_command)
-        self.bus.subscribe(SendReplyCommand.model_fields['event_type'].default, self._handle_send_reply_command)
-        self.bus.subscribe(SetTypingIndicatorCommand.model_fields['event_type'].default, self._handle_set_typing_command)
-        self.bus.subscribe(SetPresenceCommand.model_fields['event_type'].default, self._handle_set_presence_command)
-        self.bus.subscribe(RequestMatrixRoomInfoCommand.model_fields['event_type'].default, self._handle_request_room_info)
+        self.bus.subscribe(SendMatrixMessageCommand.get_event_type(), self._handle_send_message_command)
+        self.bus.subscribe(ReactToMessageCommand.get_event_type(), self._handle_react_to_message_command)
+        self.bus.subscribe(SendReplyCommand.get_event_type(), self._handle_send_reply_command)
+        self.bus.subscribe(SetTypingIndicatorCommand.get_event_type(), self._handle_set_typing_command)
+        self.bus.subscribe(SetPresenceCommand.get_event_type(), self._handle_set_presence_command)
+        self.bus.subscribe(RequestMatrixRoomInfoCommand.get_event_type(), self._handle_request_room_info)
 
         self._command_worker_task = asyncio.create_task(self._command_worker())
 

--- a/ollama_inference_service.py
+++ b/ollama_inference_service.py
@@ -117,7 +117,7 @@ class OllamaInferenceService:
 
     async def run(self):
         logger.info("OllamaInferenceService: Starting...")
-        self.bus.subscribe(OllamaInferenceRequestEvent.model_fields['event_type'].default, self._handle_inference_request)
+        self.bus.subscribe(OllamaInferenceRequestEvent.get_event_type(), self._handle_inference_request)
         
         try:
             await self._stop_event.wait()

--- a/room_logic_service.py
+++ b/room_logic_service.py
@@ -778,9 +778,9 @@ class RoomLogicService:
 
     async def run(self):
         """Main run loop for the service, subscribing to events."""
-        self.bus.subscribe(MatrixMessageReceivedEvent.model_fields['event_type'].default, self._handle_matrix_message)
-        self.bus.subscribe(ActivateListeningEvent.model_fields['event_type'].default, self._handle_activate_listening)
-        self.bus.subscribe(ProcessMessageBatchCommand.model_fields['event_type'].default, self._handle_process_message_batch)
+        self.bus.subscribe(MatrixMessageReceivedEvent.get_event_type(), self._handle_matrix_message)
+        self.bus.subscribe(ActivateListeningEvent.get_event_type(), self._handle_activate_listening)
+        self.bus.subscribe(ProcessMessageBatchCommand.get_event_type(), self._handle_process_message_batch)
         
         # Subscribe to specific AI response events for chat.
         # The _handle_ai_chat_response method itself checks response_event.response_topic.
@@ -788,16 +788,16 @@ class RoomLogicService:
         # We remove the subscription to the generic AIInferenceResponseEvent for this handler
         # to prevent double calls if the message bus delivers an event to handlers for both
         # its specific type and its base type.
-        self.bus.subscribe(OpenRouterInferenceResponseEvent.model_fields['event_type'].default, self._handle_ai_chat_response)
-        self.bus.subscribe(OllamaInferenceResponseEvent.model_fields['event_type'].default, self._handle_ai_chat_response)
+        self.bus.subscribe(OpenRouterInferenceResponseEvent.get_event_type(), self._handle_ai_chat_response)
+        self.bus.subscribe(OllamaInferenceResponseEvent.get_event_type(), self._handle_ai_chat_response)
         # If other specific chat response events exist, they should be subscribed here.
         # A generic AIInferenceResponseEvent for chat, if not covered by specific types, would need careful handling
         # or a separate handler if it implies different processing. For now, assuming specific types cover chat.
 
         # Subscribe to specific AI response events for summary.
         # Similar to chat responses, removed generic subscription to avoid double calls.
-        self.bus.subscribe(OpenRouterInferenceResponseEvent.model_fields['event_type'].default, self._handle_ai_summary_response)
-        self.bus.subscribe(OllamaInferenceResponseEvent.model_fields['event_type'].default, self._handle_ai_summary_response)
+        self.bus.subscribe(OpenRouterInferenceResponseEvent.get_event_type(), self._handle_ai_summary_response)
+        self.bus.subscribe(OllamaInferenceResponseEvent.get_event_type(), self._handle_ai_summary_response)
     
         # Fallback subscriptions for truly generic AIInferenceResponseEvents,
         # only if they are not instances of the more specific types handled above
@@ -810,8 +810,8 @@ class RoomLogicService:
         # for chat or summary, separate logic or a more sophisticated subscription mechanism might be needed.
         # Based on current usage, specific events are published by AIInferenceService.
         
-        self.bus.subscribe(BotDisplayNameReadyEvent.model_fields['event_type'].default, self._handle_bot_display_name_ready)
-        self.bus.subscribe(ToolExecutionResponse.model_fields['event_type'].default, self._handle_tool_execution_response)
+        self.bus.subscribe(BotDisplayNameReadyEvent.get_event_type(), self._handle_bot_display_name_ready)
+        self.bus.subscribe(ToolExecutionResponse.get_event_type(), self._handle_tool_execution_response)
         
         await self._stop_event.wait()
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 import sqlite3
 import os
 # The plan mentioned a SummaryData Pydantic model, but database.py currently returns a tuple.
@@ -6,7 +7,7 @@ import os
 # from database import initialize_database, update_summary, get_summary, SummaryData # Assuming SummaryData if it were used
 from database import initialize_database, update_summary, get_summary
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def test_db_path(tmp_path):
     """Fixture to provide a temporary database path and initialize the DB."""
     db_file = tmp_path / "test_matrix_bot.db"

--- a/tests/service/test_ai_inference_service.py
+++ b/tests/service/test_ai_inference_service.py
@@ -253,8 +253,8 @@ async def test_service_subscribes_to_openrouter_requests_on_run(
 
 
         mock_message_bus.subscribe.assert_any_call(
-            OpenRouterInferenceRequestEvent.model_fields['event_type'].default, 
-            ai_service._handle_inference_request 
+            OpenRouterInferenceRequestEvent.get_event_type(),
+            ai_service._handle_inference_request
         )
         
         # To test the handler being called, we can simulate a publish

--- a/tests/unit/test_prompt_constructor.py
+++ b/tests/unit/test_prompt_constructor.py
@@ -26,12 +26,12 @@ def test_build_status_prompt():
 @patch('prompt_constructor.database')
 @pytest.mark.asyncio
 async def test_get_formatted_system_prompt_all_parts(mock_db):
-    mock_db.get_prompt.return_value = ("Test system prompt template with {bot_identity_section}, {global_summary_section}, {user_memories_section}, and {tool_states_section}.", None)
-    mock_db.get_latest_global_summary.return_value = ("Test global summary", None)
-    mock_db.get_user_memories.return_value = [
+    mock_db.get_prompt = AsyncMock(return_value=("Test system prompt template with {bot_identity_section}, {global_summary_section}, {user_memories_section}, and {tool_states_section}.", None))
+    mock_db.get_latest_global_summary = AsyncMock(return_value=("Test global summary", None))
+    mock_db.get_user_memories = AsyncMock(return_value=[
         (1, "user1", "Memory 1 for user1", 1678886400),
         (2, "user1", "Memory 2 for user1", 1678886500),
-    ]
+    ])
     tool_states = {"tool_a": {"state": "active"}, "tool_b": {"count": 5}}
     
     prompt = await get_formatted_system_prompt(
@@ -52,9 +52,9 @@ async def test_get_formatted_system_prompt_all_parts(mock_db):
 @patch('prompt_constructor.database')
 @pytest.mark.asyncio
 async def test_get_formatted_system_prompt_no_channel_summary(mock_db):
-    mock_db.get_prompt.return_value = ("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None)
-    mock_db.get_latest_global_summary.return_value = ("Global summary", None)
-    mock_db.get_user_memories.return_value = []
+    mock_db.get_prompt = AsyncMock(return_value=("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None))
+    mock_db.get_latest_global_summary = AsyncMock(return_value=("Global summary", None))
+    mock_db.get_user_memories = AsyncMock(return_value=[])
     prompt = await get_formatted_system_prompt("TestBot", None, None, "dummy_db.sqlite", [])
     assert "TestBot" in prompt
     assert "Global summary" in prompt
@@ -65,9 +65,9 @@ async def test_get_formatted_system_prompt_no_channel_summary(mock_db):
 @patch('prompt_constructor.database')
 @pytest.mark.asyncio
 async def test_get_formatted_system_prompt_no_global_summary(mock_db):
-    mock_db.get_prompt.return_value = ("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None)
-    mock_db.get_latest_global_summary.return_value = None # No global summary
-    mock_db.get_user_memories.return_value = []
+    mock_db.get_prompt = AsyncMock(return_value=("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None))
+    mock_db.get_latest_global_summary = AsyncMock(return_value=None)
+    mock_db.get_user_memories = AsyncMock(return_value=[])
     prompt = await get_formatted_system_prompt("TestBot", "Channel summary", None, "dummy_db.sqlite", [])
     assert "TestBot" in prompt
     assert "No global summary available currently." in prompt
@@ -79,9 +79,9 @@ async def test_get_formatted_system_prompt_no_global_summary(mock_db):
 @patch('prompt_constructor.database')
 @pytest.mark.asyncio
 async def test_get_formatted_system_prompt_no_summaries_no_bot_name(mock_db):
-    mock_db.get_prompt.return_value = ("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None)
-    mock_db.get_latest_global_summary.return_value = None
-    mock_db.get_user_memories.return_value = []
+    mock_db.get_prompt = AsyncMock(return_value=("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None))
+    mock_db.get_latest_global_summary = AsyncMock(return_value=None)
+    mock_db.get_user_memories = AsyncMock(return_value=[])
     prompt = await get_formatted_system_prompt(None, None, None, "dummy_db.sqlite", [])
     assert "You are AI." in prompt # Default identity
     assert "No global summary available currently." in prompt
@@ -91,9 +91,9 @@ async def test_get_formatted_system_prompt_no_summaries_no_bot_name(mock_db):
 @patch('prompt_constructor.database')
 @pytest.mark.asyncio
 async def test_get_formatted_system_prompt_only_bot_name(mock_db):
-    mock_db.get_prompt.return_value = ("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None)
-    mock_db.get_latest_global_summary.return_value = None
-    mock_db.get_user_memories.return_value = []
+    mock_db.get_prompt = AsyncMock(return_value=("System prompt: {bot_identity_section}, {global_summary_section}, {user_memories_section}, {tool_states_section}", None))
+    mock_db.get_latest_global_summary = AsyncMock(return_value=None)
+    mock_db.get_user_memories = AsyncMock(return_value=[])
     prompt = await get_formatted_system_prompt("NamedBot", None, None, "dummy_db.sqlite", [])
     assert "You are NamedBot, AI." in prompt
     assert "No global summary available currently." in prompt

--- a/tool_execution_service.py
+++ b/tool_execution_service.py
@@ -193,11 +193,11 @@ class ToolExecutionService:
 
     async def run(self) -> None:
         logger.info("ToolExecutionService: Starting...")
-        self.bus.subscribe(ExecuteToolRequest.model_fields['event_type'].default, self._handle_execute_tool_request)
+        self.bus.subscribe(ExecuteToolRequest.get_event_type(), self._handle_execute_tool_request)
         # Subscribe to the specific event type that OpenRouterInferenceService will publish to
         # when a response for a DelegateToOpenRouterTool call is ready.
         self.bus.subscribe(DELEGATED_OPENROUTER_RESPONSE_EVENT_TYPE, self._handle_delegated_openrouter_response)
-        self.bus.subscribe(MatrixRoomInfoResponseEvent.model_fields['event_type'].default, self._handle_room_info_response)
+        self.bus.subscribe(MatrixRoomInfoResponseEvent.get_event_type(), self._handle_room_info_response)
         await self._stop_event.wait()
         logger.info("ToolExecutionService: Stopped.")
 


### PR DESCRIPTION
## Summary
- introduce `EventType` enum in `event_definitions`
- update all event models to use the enum
- adjust `MessageBus` to accept enum types
- update services and tests to use `EventType`
- fix async fixture in database tests and use `AsyncMock` in prompt constructor tests

## Testing
- `pytest -q`