### PR TITLE
Add tool call history tracking and validation

### DIFF
--- a/event_definitions.py
+++ b/event_definitions.py
@@ -308,6 +308,7 @@ class ToolExecutionResponse(BaseEvent):
     data_from_tool_for_followup_llm: Optional[Dict[str, Any]] = None
     original_request_payload: Dict[str, Any] = Field(default_factory=dict)
     # Added from test
-    commands_to_publish: Optional[List[BaseEvent]] = None 
+    commands_to_publish: Optional[List[BaseEvent]] = None
+    original_tool_call: Optional[ToolCall] = None
     # original_ai_request_event_id: Optional[str] = None # From test, map to original_request_payload
 

--- a/image_analysis_service.py
+++ b/image_analysis_service.py
@@ -45,6 +45,7 @@ class ImageAnalysisService:
             error_message=error_message,
             original_request_payload={"room_id": room_id},
             commands_to_publish=None,
+            original_tool_call=None,
         )
 
         await self.bus.publish(tool_response)

--- a/tests/service/test_ai_inference_service.py
+++ b/tests/service/test_ai_inference_service.py
@@ -229,6 +229,48 @@ async def test_api_payload_construction_with_optional_params(
     assert api_payload["tool_choice"] == "auto"
     assert api_payload["tools"] == request_event.tools
 
+
+@pytest.mark.asyncio
+async def test_anthropic_payload_conversion(
+    ai_service: AIInferenceService,
+    mock_message_bus: MagicMock,
+    mock_httpx_client_post: AsyncMock,
+):
+    request_event = OpenRouterInferenceRequestEvent(
+        request_id="anthropic_req",
+        reply_to_service_event="reply_event",
+        model_name="anthropic/claude-3-sonnet",
+        messages_payload=[
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call1",
+                        "type": "function",
+                        "function": {"name": "ping", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call1", "content": "pong"},
+        ],
+        original_request_payload={},
+    )
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+    mock_httpx_client_post.return_value = mock_response
+
+    await ai_service._handle_inference_request(request_event)
+
+    sent_messages = mock_httpx_client_post.call_args[1]["json"]["messages"]
+    assert sent_messages[0]["role"] == "assistant"
+    assert isinstance(sent_messages[0]["content"], list)
+    assert sent_messages[0]["content"][0]["type"] == "tool_use"
+    assert sent_messages[1]["role"] == "user"
+    assert sent_messages[1]["content"][0]["type"] == "tool_result"
+
 # Example of how to start testing the main run loop and subscription
 # This is more of an integration test for the service's core behavior.
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track pending tool calls in room logic
- add message history validation in AI inference
- store timestamps for short-term memory entries
- include original tool call in execution responses
- convert Anthropic payload and validate before request

## Testing
- `pytest -q`