### PR TITLE
Secure external control boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ AI_INCLUDE_DETAILED_USER_INFO=true
 # Farcaster Bot Identity (to prevent self-replies)
 FARCASTER_BOT_FID=
 FARCASTER_BOT_USERNAME=
+FARCASTER_WEBHOOK_SECRET=
 
 # Matrix Configuration (Required)
 MATRIX_HOMESERVER=http://synapse:8008  # Updated to use containerized Synapse
@@ -28,7 +29,23 @@ MATRIX_USER_ID=@your-bot:your.domain.com
 MATRIX_PASSWORD=yourpassword
 MATRIX_ROOM_ID=!yourRoom:your.domain.com
 MATRIX_DEVICE_ID=
+
+# Telegram
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ALLOWED_CHAT_IDS=
+TELEGRAM_ALLOWED_SENDER_IDS=
+TELEGRAM_MESSAGE_RATE_LIMIT_PER_MINUTE=10
+TELEGRAM_MAX_MESSAGE_CHARS=4000
+TELEGRAM_OFFSET_PATH=data/telegram_offset.txt
+TELEGRAM_OPERATOR_QUEUE_PATH=data/telegram_operator_queue.jsonl
+TELEGRAM_OPERATOR_QUEUE_MAX_BYTES=1048576
 DEVICE_NAME=NioChatBotSOA-Gateway
+
+# Local management API (generate a long random token; do not commit it)
+ADMIN_API_TOKEN=
+ADMIN_API_HOST=127.0.0.1
+ADMIN_API_PORT=8000
+ADMIN_API_ALLOWED_ORIGINS=http://127.0.0.1:8000,http://localhost:8000,http://localhost:3000
 
 # OpenRouter API (Required)
 OPENROUTER_API_KEY=your-openrouter-api-key
@@ -36,6 +53,9 @@ AI_MODEL=openai/gpt-4o-mini
 AI_MULTIMODAL_MODEL=openai/gpt-4o
 YOUR_SITE_URL=https://your-site-url.com
 YOUR_SITE_NAME=My Chatbot
+FRAMES_BASE_URL=
+# Required to accept frame actions; use at least 32 random bytes.
+FRAMES_WEBHOOK_SECRET=
 
 # Farcaster Configuration (Optional)
 NEYNAR_API_KEY=your_neynar_api_key_here
@@ -53,6 +73,13 @@ LOG_LEVEL=INFO
 
 # Database
 CHATBOT_DB_PATH=/app/data/chatbot.db
+CHATBOT_ENV=development
+# Required in production. Generate with:
+# python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+INTEGRATION_CREDENTIAL_KEY=
+
+# Required by the wallet-backed internal uploader (at least 32 random bytes).
+ARWEAVE_UPLOADER_API_KEY=
 
 # --- Ollama Configuration ---
 PRIMARY_LLM_PROVIDER=openrouter # or "ollama"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+data/telegram_offset.txt
+data/telegram_operator_queue.jsonl
 *.py[cod]
 *$py.class
 

--- a/arweave-service/main.py
+++ b/arweave-service/main.py
@@ -3,6 +3,7 @@ Arweave Service - Secure, lean microservice for Arweave uploads
 This service expects a pre-provisioned wallet file and does NOT generate wallets.
 """
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -114,10 +115,28 @@ wallet_manager = get_wallet()
 
 # API Key for basic authentication
 API_KEY = os.getenv("ARWEAVE_SERVICE_API_KEY")
+MAX_UPLOAD_BYTES = int(os.getenv("ARWEAVE_MAX_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+
+
+def _validate_content_type(content_type: str) -> str:
+    """Reject oversized metadata and newline-based tag injection."""
+    if (
+        not content_type
+        or len(content_type) > 255
+        or "\r" in content_type
+        or "\n" in content_type
+    ):
+        raise HTTPException(status_code=400, detail="Invalid content type")
+    return content_type
+
 
 def validate_api_key(x_api_key: Optional[str] = None):
-    """Validate API key if one is configured"""
-    if API_KEY and x_api_key != API_KEY:
+    """Require an explicitly configured, sufficiently strong API key."""
+    if not API_KEY or len(API_KEY.encode("utf-8")) < 32:
+        raise HTTPException(
+            status_code=503, detail="Arweave service authentication is not configured"
+        )
+    if not x_api_key or not hmac.compare_digest(x_api_key, API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API Key")
 
 @app.on_event("startup")
@@ -142,8 +161,11 @@ async def health_check():
     )
 
 @app.get("/wallet", response_model=WalletInfo)
-async def get_wallet_info():
+async def get_wallet_info(
+    x_api_key: Annotated[str | None, Header()] = None
+):
     """Get wallet information"""
+    validate_api_key(x_api_key)
     if not wallet_manager.is_ready():
         raise HTTPException(status_code=503, detail="Wallet not initialized")
     
@@ -165,10 +187,14 @@ async def _parse_tags(tags: Optional[str]) -> Dict[str, str]:
     
     try:
         tag_dict = json.loads(tags)
-        return {key: str(value) for key, value in tag_dict.items()}
-    except json.JSONDecodeError:
-        logger.warning(f"Invalid tags JSON provided: {tags}")
-        return {}
+        if not isinstance(tag_dict, dict) or len(tag_dict) > 20:
+            raise ValueError("Tags must be an object with at most 20 entries")
+        normalized = {str(key): str(value) for key, value in tag_dict.items()}
+        if any(len(key) > 128 or len(value) > 1024 for key, value in normalized.items()):
+            raise ValueError("Tag key or value exceeds the allowed length")
+        return normalized
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 async def _create_and_send_transaction(
     data: bytes, 
@@ -248,11 +274,16 @@ async def upload_to_arweave(
     
     try:
         # Read file content
-        file_content = await file.read()
+        file_content = await file.read(MAX_UPLOAD_BYTES + 1)
         if not file_content:
             raise HTTPException(status_code=400, detail="Empty file provided")
-        
-        logger.info(f"Uploading file: {file.filename} ({len(file_content)} bytes)")
+        if len(file_content) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Upload exceeds size limit")
+        content_type = _validate_content_type(
+            file.content_type or "application/octet-stream"
+        )
+
+        logger.info("Uploading file (%s bytes)", len(file_content))
         
         # Parse custom tags
         custom_tags = await _parse_tags(tags)
@@ -260,12 +291,14 @@ async def upload_to_arweave(
         # Prepare additional system tags
         additional_tags = {}
         if file.filename:
+            if len(file.filename) > 255 or "\r" in file.filename or "\n" in file.filename:
+                raise HTTPException(status_code=400, detail="Invalid file name")
             additional_tags['File-Name'] = file.filename
         
         # Create and send transaction
         transaction = await _create_and_send_transaction(
             data=file_content,
-            content_type=file.content_type or "application/octet-stream",
+            content_type=content_type,
             custom_tags=custom_tags,
             additional_tags=additional_tags
         )
@@ -274,15 +307,17 @@ async def upload_to_arweave(
         response = _create_upload_response(
             transaction=transaction,
             data_size=len(file_content),
-            content_type=file.content_type or "application/octet-stream"
+            content_type=content_type
         )
         
         logger.info(f"Upload successful: {transaction.id}")
         return response
         
-    except Exception as e:
-        logger.error(f"Upload failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Upload failed")
+        raise HTTPException(status_code=500, detail="Upload failed")
 
 @app.post("/upload/data", response_model=UploadResponse)
 async def upload_data_to_arweave(
@@ -308,6 +343,11 @@ async def upload_data_to_arweave(
     
     try:
         data_bytes = data.encode('utf-8')
+        if not data_bytes:
+            raise HTTPException(status_code=400, detail="Empty data provided")
+        if len(data_bytes) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Upload exceeds size limit")
+        content_type = _validate_content_type(content_type)
         logger.info(f"Uploading data ({len(data_bytes)} bytes)")
         
         # Parse custom tags
@@ -330,9 +370,11 @@ async def upload_data_to_arweave(
         logger.info(f"Data upload successful: {transaction.id}")
         return response
         
-    except Exception as e:
-        logger.error(f"Data upload failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Data upload failed: {str(e)}")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Data upload failed")
+        raise HTTPException(status_code=500, detail="Data upload failed")
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/arweave-service/test_main.py
+++ b/arweave-service/test_main.py
@@ -13,10 +13,13 @@ from fastapi.testclient import TestClient
 from fastapi import HTTPException
 
 # Import the main application and classes
+import main
 from main import (
     app, ArweaveWalletManager, validate_api_key, 
     UploadResponse, WalletInfo, HealthResponse
 )
+
+TEST_API_KEY = "a" * 32
 
 
 class TestArweaveWalletManager:
@@ -117,25 +120,25 @@ class TestAPIKeyValidation:
     
     def test_validate_api_key_no_key_configured(self):
         """Test validation when no API key is configured"""
-        with patch.dict(os.environ, {}, clear=True):
-            # Should not raise any exception
-            validate_api_key("any_key")
-            validate_api_key(None)
+        with patch.object(main, "API_KEY", None):
+            with pytest.raises(HTTPException) as exc_info:
+                main.validate_api_key(None)
+            assert exc_info.value.status_code == 503
             
     def test_validate_api_key_valid(self):
         """Test validation with correct API key"""
-        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": "secret123"}):
+        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": TEST_API_KEY}):
             # Import after setting env var to get updated API_KEY
             from importlib import reload
             import main
             reload(main)
             
             # Should not raise any exception
-            main.validate_api_key("secret123")
+            main.validate_api_key(TEST_API_KEY)
             
     def test_validate_api_key_invalid(self):
         """Test validation with incorrect API key"""
-        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": "secret123"}):
+        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": TEST_API_KEY}):
             from importlib import reload
             import main
             reload(main)
@@ -148,7 +151,7 @@ class TestAPIKeyValidation:
             
     def test_validate_api_key_missing(self):
         """Test validation when API key is required but not provided"""
-        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": "secret123"}):
+        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": TEST_API_KEY}):
             from importlib import reload
             import main
             reload(main)
@@ -165,7 +168,8 @@ class TestEndpoints:
     
     def setup_method(self):
         """Setup test client for each test"""
-        self.client = TestClient(app)
+        main.API_KEY = TEST_API_KEY
+        self.client = TestClient(app, headers={"X-API-Key": TEST_API_KEY})
         
     def test_health_check_wallet_not_ready(self):
         """Test health check when wallet is not ready"""
@@ -280,7 +284,7 @@ class TestEndpoints:
             
     def test_upload_file_with_api_key(self):
         """Test file upload with API key authentication"""
-        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": "secret123"}), \
+        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": TEST_API_KEY}), \
              patch('main.wallet_manager') as mock_manager, \
              patch('main.Transaction') as mock_transaction_class, \
              patch('asyncio.to_thread') as mock_to_thread:
@@ -306,7 +310,7 @@ class TestEndpoints:
             mock_to_thread.return_value.set_result(None)
             
             files = {"file": ("test.txt", b"test content", "text/plain")}
-            headers = {"X-API-Key": "secret123"}
+            headers = {"X-API-Key": TEST_API_KEY}
             
             client = TestClient(main.app)
             response = client.post("/upload", files=files, headers=headers)
@@ -315,7 +319,7 @@ class TestEndpoints:
             
     def test_upload_file_invalid_api_key(self):
         """Test file upload with invalid API key"""
-        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": "secret123"}):
+        with patch.dict(os.environ, {"ARWEAVE_SERVICE_API_KEY": TEST_API_KEY}):
             from importlib import reload
             import main
             reload(main)

--- a/arweave_uploader_service/main.py
+++ b/arweave_uploader_service/main.py
@@ -2,9 +2,11 @@
 Arweave Uploader Service - Microservice for handling direct Arweave uploads
 """
 import asyncio
+import hmac
 import json
 import logging
 import os
+import string
 from typing import Dict, List, Optional, Annotated
 
 import uvicorn
@@ -135,11 +137,18 @@ wallet_manager: Optional[ArweaveWalletManager] = None
 
 # Optional API key for internal service authentication
 API_KEY = os.getenv("ARWEAVE_UPLOADER_API_KEY")
+MAX_UPLOAD_BYTES = int(os.getenv("ARWEAVE_MAX_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+VALID_TX_ID_CHARS = frozenset(string.ascii_letters + string.digits + "_-")
 
 
 def verify_api_key(x_api_key: Annotated[str | None, Header()] = None):
-    """Verify API key if configured."""
-    if API_KEY and x_api_key != API_KEY:
+    """Require an explicitly configured, sufficiently strong API key."""
+    if not API_KEY or len(API_KEY.encode("utf-8")) < 32:
+        raise HTTPException(
+            status_code=503,
+            detail="Arweave uploader authentication is not configured",
+        )
+    if not x_api_key or not hmac.compare_digest(x_api_key, API_KEY):
         raise HTTPException(
             status_code=401,
             detail="Invalid or missing API key"
@@ -169,8 +178,13 @@ def _parse_tags(tags: Optional[str]) -> Optional[List[Dict[str, str]]]:
     
     try:
         parsed_tags = json.loads(tags)
-        if not isinstance(parsed_tags, list):
-            raise ValueError("Tags must be a list")
+        if not isinstance(parsed_tags, list) or len(parsed_tags) > 20:
+            raise ValueError("Tags must be a list with at most 20 entries")
+        for tag in parsed_tags:
+            if not isinstance(tag, dict) or set(tag) != {"name", "value"}:
+                raise ValueError("Each tag must contain only name and value")
+            if len(str(tag["name"])) > 128 or len(str(tag["value"])) > 1024:
+                raise ValueError("Tag name or value exceeds the allowed length")
         return parsed_tags
     except (json.JSONDecodeError, ValueError) as e:
         logger.warning(f"Invalid tags format: {e}")
@@ -178,6 +192,19 @@ def _parse_tags(tags: Optional[str]) -> Optional[List[Dict[str, str]]]:
             status_code=400,
             detail=f"Invalid tags format. Expected JSON list: {str(e)}"
         )
+
+
+def _validate_content_type(content_type: str) -> str:
+    """Reject metadata that is oversized or can inject additional headers/tags."""
+    if (
+        not content_type
+        or len(content_type) > 255
+        or "\r" in content_type
+        or "\n" in content_type
+    ):
+        raise HTTPException(status_code=400, detail="Invalid content type")
+    return content_type
+
 
 @app.post("/upload")
 async def upload_file(
@@ -195,7 +222,12 @@ async def upload_file(
     
     try:
         # Read file data
-        file_data = await file.read()
+        file_data = await file.read(MAX_UPLOAD_BYTES + 1)
+        if not file_data:
+            raise HTTPException(status_code=400, detail="Empty file provided")
+        if len(file_data) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="Upload exceeds size limit")
+        content_type = _validate_content_type(content_type)
         
         # Parse tags if provided
         parsed_tags = _parse_tags(tags)
@@ -222,7 +254,7 @@ async def upload_file(
         logger.error(f"Upload endpoint error: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=f"Internal server error: {str(e)}"
+            detail="Internal server error"
         )
 
 @app.get("/wallet-info")
@@ -264,7 +296,7 @@ async def get_wallet_info(_: bool = Depends(verify_api_key)):
         logger.error(f"Error getting wallet info: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get wallet info: {str(e)}"
+            detail="Failed to get wallet info"
         )
 
 @app.get("/status/{tx_id}")
@@ -275,6 +307,8 @@ async def get_transaction_status(tx_id: str, _: bool = Depends(verify_api_key)):
             status_code=503,
             detail="Arweave wallet not initialized"
         )
+    if len(tx_id) != 43 or any(char not in VALID_TX_ID_CHARS for char in tx_id):
+        raise HTTPException(status_code=400, detail="Invalid transaction ID")
     
     try:
         # Use the Arweave Python library to check transaction status
@@ -299,7 +333,7 @@ async def get_transaction_status(tx_id: str, _: bool = Depends(verify_api_key)):
         logger.error(f"Error getting transaction status: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get transaction status: {str(e)}"
+            detail="Failed to get transaction status"
         )
 
 @app.get("/health")

--- a/chatbot/api_server/__init__.py
+++ b/chatbot/api_server/__init__.py
@@ -5,6 +5,16 @@ This package provides a modular FastAPI-based REST API for monitoring and contro
 the chatbot system, with organized routers for different functional areas.
 """
 
-from .main import ChatbotAPIServer, create_api_server
-
 __all__ = ["ChatbotAPIServer", "create_api_server"]
+
+
+def __getattr__(name):
+    """Avoid importing the full FastAPI/orchestrator graph for helper modules."""
+    if name in __all__:
+        from .main import ChatbotAPIServer, create_api_server
+
+        return {
+            "ChatbotAPIServer": ChatbotAPIServer,
+            "create_api_server": create_api_server,
+        }[name]
+    raise AttributeError(name)

--- a/chatbot/api_server/auth.py
+++ b/chatbot/api_server/auth.py
@@ -1,0 +1,57 @@
+"""Authentication helpers for the local management API."""
+
+import base64
+import hmac
+from typing import Mapping, Optional
+
+from chatbot.config import settings
+
+MIN_ADMIN_TOKEN_LENGTH = 32
+
+
+def configured_admin_token() -> Optional[str]:
+    token = settings.ADMIN_API_TOKEN
+    if token and len(token.encode("utf-8")) >= MIN_ADMIN_TOKEN_LENGTH:
+        return token
+    return None
+
+
+def supplied_admin_token(headers: Mapping[str, str]) -> Optional[str]:
+    authorization = headers.get("authorization", "")
+    if authorization.startswith("Bearer "):
+        candidate = authorization[7:]
+        return candidate or None
+    direct_token = headers.get("x-admin-token")
+    if direct_token:
+        return direct_token
+
+    for protocol in headers.get("sec-websocket-protocol", "").split(","):
+        protocol = protocol.strip()
+        if not protocol.startswith("auth."):
+            continue
+        encoded = protocol[5:]
+        try:
+            padding = "=" * (-len(encoded) % 4)
+            return base64.urlsafe_b64decode(encoded + padding).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return None
+    return None
+
+
+def is_admin_authorized(headers: Mapping[str, str]) -> bool:
+    expected = configured_admin_token()
+    supplied = supplied_admin_token(headers)
+    if expected is None or supplied is None:
+        return False
+    return hmac.compare_digest(
+        supplied.encode("utf-8"),
+        expected.encode("utf-8"),
+    )
+
+
+def allowed_origins() -> list[str]:
+    return [
+        origin.strip()
+        for origin in settings.ADMIN_API_ALLOWED_ORIGINS.split(",")
+        if origin.strip()
+    ]

--- a/chatbot/api_server/main.py
+++ b/chatbot/api_server/main.py
@@ -9,14 +9,15 @@ import logging
 from datetime import datetime
 from typing import Any, Dict
 
-from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, Depends
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
+from fastapi.responses import JSONResponse
 
 from chatbot.core.orchestration import MainOrchestrator
 from .services import SetupManager, LogWebSocketManager
 from .routers import system, tools, config, integrations, ai, worldstate, setup, logs, ui_frames
 from .schemas import StatusResponse
+from .auth import allowed_origins, configured_admin_token, is_admin_authorized
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +49,43 @@ class ChatbotAPIServer:
         """Configure CORS and other middleware."""
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],  # Configure appropriately for production
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_origins=allowed_origins(),
+            allow_credentials=False,
+            allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+            allow_headers=["Authorization", "Content-Type", "X-Admin-Token"],
         )
+
+        @self.app.middleware("http")
+        async def require_admin_authentication(request, call_next):
+            public_paths = {"/health", "/api/system/health"}
+            protected_documentation = {
+                "/docs",
+                "/docs/oauth2-redirect",
+                "/openapi.json",
+                "/redoc",
+            }
+            if (
+                request.method != "OPTIONS"
+                and (
+                    request.url.path.startswith("/api/")
+                    or request.url.path in protected_documentation
+                )
+                and request.url.path not in public_paths
+            ):
+                if configured_admin_token() is None:
+                    return JSONResponse(
+                        status_code=503,
+                        content={
+                            "detail": "Management API authentication is not configured"
+                        },
+                    )
+                if not is_admin_authorized(request.headers):
+                    return JSONResponse(
+                        status_code=401,
+                        content={"detail": "Invalid or missing management API token"},
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
+            return await call_next(request)
     
     def _setup_dependency_overrides(self):
         """Set up dependency injection overrides for routers."""
@@ -113,7 +146,26 @@ class ChatbotAPIServer:
         @self.app.websocket("/ws/logs")
         async def websocket_logs(websocket: WebSocket):
             """WebSocket endpoint for real-time log streaming."""
-            await self.log_manager.connect(websocket)
+            if configured_admin_token() is None:
+                await websocket.close(code=1013, reason="Authentication not configured")
+                return
+            if not is_admin_authorized(websocket.headers):
+                await websocket.close(code=4401, reason="Unauthorized")
+                return
+            requested_protocols = {
+                protocol.strip()
+                for protocol in websocket.headers.get(
+                    "sec-websocket-protocol", ""
+                ).split(",")
+            }
+            selected_protocol = (
+                "ratichat-admin"
+                if "ratichat-admin" in requested_protocols
+                else None
+            )
+            await self.log_manager.connect(
+                websocket, subprotocol=selected_protocol
+            )
             try:
                 while True:
                     # Keep connection alive and handle client messages if needed

--- a/chatbot/api_server/routers/ai.py
+++ b/chatbot/api_server/routers/ai.py
@@ -33,9 +33,9 @@ async def get_ai_prompt(orchestrator: MainOrchestrator = Depends(get_orchestrato
             "enabled_tools_count": len(orchestrator.tool_registry.get_enabled_tools()),
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting AI prompt: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting AI prompt")
+        raise HTTPException(status_code=500, detail="Unable to get AI prompt")
 
 
 @router.get("/models")
@@ -59,6 +59,6 @@ async def get_ai_models():
             ],
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting AI models: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting AI models")
+        raise HTTPException(status_code=500, detail="Unable to get AI models")

--- a/chatbot/api_server/routers/config.py
+++ b/chatbot/api_server/routers/config.py
@@ -42,17 +42,21 @@ async def get_configuration(orchestrator: MainOrchestrator = Depends(get_orchest
                 "max_actions_per_hour": getattr(settings, 'MAX_ACTIONS_PER_HOUR', 600),
                 "image_generation_cooldown": settings.IMAGE_GENERATION_COOLDOWN_SECONDS,
                 "video_generation_cooldown": settings.VIDEO_GENERATION_COOLDOWN_SECONDS,
-                "farcaster_post_cooldown": settings.FARCASTER_POST_COOLDOWN_SECONDS
+                "farcaster_post_cooldown": getattr(
+                    settings, "FARCASTER_POST_COOLDOWN_SECONDS", 0
+                )
             },
             "integrations": {
                 "matrix_enabled": bool(settings.MATRIX_USER_ID and settings.MATRIX_PASSWORD),
                 "farcaster_enabled": bool(settings.NEYNAR_API_KEY),
-                "arweave_enabled": bool(settings.ARWEAVE_WALLET_PATH),
+                "arweave_enabled": bool(
+                    settings.ARWEAVE_INTERNAL_UPLOADER_SERVICE_URL
+                ),
                 "replicate_enabled": bool(settings.REPLICATE_API_TOKEN),
                 "google_ai_enabled": bool(settings.GOOGLE_API_KEY)
             },
             "storage": {
-                "db_path": settings.DB_PATH,
+                "db_path": settings.CHATBOT_DB_PATH,
                 "context_storage_enabled": True,
                 "history_retention_days": getattr(settings, 'HISTORY_RETENTION_DAYS', 30)
             },
@@ -76,9 +80,9 @@ async def get_configuration(orchestrator: MainOrchestrator = Depends(get_orchest
             ]
         }
         
-    except Exception as e:
-        logger.error(f"Error getting configuration: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to get configuration: {str(e)}")
+    except Exception:
+        logger.exception("Error getting configuration")
+        raise HTTPException(status_code=500, detail="Failed to get configuration")
 
 
 @router.put("", response_model=StatusResponse)
@@ -129,8 +133,9 @@ async def update_configuration(
         # Apply the update
         try:
             allowed_updates[key](value)
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Failed to apply update: {str(e)}")
+        except Exception:
+            logger.exception("Failed to apply configuration update for %s", key)
+            raise HTTPException(status_code=400, detail="Failed to apply update")
         
         # For some updates, we might need to notify other components
         if key.startswith("processing."):
@@ -149,6 +154,6 @@ async def update_configuration(
         
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error updating configuration: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to update configuration: {str(e)}")
+    except Exception:
+        logger.exception("Error updating configuration")
+        raise HTTPException(status_code=500, detail="Failed to update configuration")

--- a/chatbot/api_server/routers/integrations.py
+++ b/chatbot/api_server/routers/integrations.py
@@ -10,7 +10,7 @@ This module handles all integration-related endpoints including:
 
 from typing import Dict, Any, List
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 import logging
 
@@ -30,14 +30,14 @@ class IntegrationConfig(BaseModel):
     integration_type: str
     display_name: str
     config: Dict[str, Any]
-    credentials: Dict[str, str] = {}
+    credentials: Dict[str, str] = Field(default_factory=dict)
 
 
 class IntegrationTestRequest(BaseModel):
     """Model for testing integration configurations."""
     integration_type: str
     config: Dict[str, Any]
-    credentials: Dict[str, str] = {}
+    credentials: Dict[str, str] = Field(default_factory=dict)
 
 
 @router.get("")
@@ -46,9 +46,26 @@ async def list_integrations(orchestrator: MainOrchestrator = Depends(get_orchest
     try:
         integrations = await orchestrator.integration_manager.list_integrations()
         return integrations
-    except Exception as e:
-        logger.error(f"Error listing integrations: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error listing integrations")
+        raise HTTPException(status_code=500, detail="Unable to list integrations")
+
+
+@router.get("/types")
+async def get_available_integration_types(
+    orchestrator: MainOrchestrator = Depends(get_orchestrator)
+):
+    """Get list of available integration types."""
+    try:
+        integration_types = (
+            orchestrator.integration_manager.get_available_integration_types()
+        )
+        return {"integration_types": integration_types}
+    except Exception:
+        logger.exception("Error getting integration types")
+        raise HTTPException(
+            status_code=500, detail="Unable to list integration types"
+        )
 
 
 @router.post("")
@@ -65,9 +82,9 @@ async def add_integration(
             credentials=config.credentials
         )
         return {"integration_id": integration_id, "message": "Integration added successfully"}
-    except Exception as e:
-        logger.error(f"Error adding integration: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        logger.exception("Error adding integration")
+        raise HTTPException(status_code=400, detail="Unable to add integration")
 
 
 @router.get("/{integration_id}")
@@ -83,9 +100,9 @@ async def get_integration_status(
         return status
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error getting integration status: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting integration status")
+        raise HTTPException(status_code=500, detail="Unable to get integration status")
 
 
 @router.post("/{integration_id}/connect")
@@ -99,9 +116,9 @@ async def connect_integration(
             integration_id, orchestrator.world_state
         )
         return {"success": success, "message": "Connection attempt completed"}
-    except Exception as e:
-        logger.error(f"Error connecting integration: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error connecting integration")
+        raise HTTPException(status_code=500, detail="Unable to connect integration")
 
 
 @router.post("/{integration_id}/disconnect")
@@ -113,9 +130,9 @@ async def disconnect_integration(
     try:
         await orchestrator.integration_manager.disconnect_integration(integration_id)
         return {"message": "Integration disconnected successfully"}
-    except Exception as e:
-        logger.error(f"Error disconnecting integration: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error disconnecting integration")
+        raise HTTPException(status_code=500, detail="Unable to disconnect integration")
 
 
 @router.delete("/{integration_id}")
@@ -125,14 +142,17 @@ async def remove_integration(
 ):
     """Remove an integration configuration."""
     try:
-        # First disconnect if connected
-        await orchestrator.integration_manager.disconnect_integration(integration_id)
-        
-        # TODO: Add remove_integration method to IntegrationManager
+        removed = await orchestrator.integration_manager.remove_integration(
+            integration_id
+        )
+        if not removed:
+            raise HTTPException(status_code=404, detail="Integration not found")
         return {"message": "Integration removed successfully"}
-    except Exception as e:
-        logger.error(f"Error removing integration: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Error removing integration")
+        raise HTTPException(status_code=500, detail="Unable to remove integration")
 
 
 @router.post("/test")
@@ -148,22 +168,9 @@ async def test_integration_config(
             credentials=test_request.credentials
         )
         return result
-    except Exception as e:
-        logger.error(f"Error testing integration config: {e}")
-        raise HTTPException(status_code=400, detail=str(e))
-
-
-@router.get("/types")
-async def get_available_integration_types(
-    orchestrator: MainOrchestrator = Depends(get_orchestrator)
-):
-    """Get list of available integration types."""
-    try:
-        types = orchestrator.integration_manager.get_available_integration_types()
-        return {"integration_types": types}
-    except Exception as e:
-        logger.error(f"Error getting integration types: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error testing integration config")
+        raise HTTPException(status_code=400, detail="Unable to test integration")
 
 
 @router.get("/arweave/wallet")

--- a/chatbot/api_server/routers/logs.py
+++ b/chatbot/api_server/routers/logs.py
@@ -43,9 +43,9 @@ async def get_recent_logs():
             "count": 1,
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting recent logs: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting recent logs")
+        raise HTTPException(status_code=500, detail="Unable to get recent logs")
 
 
 @router.get("/history/actions")
@@ -69,6 +69,6 @@ async def get_action_history(orchestrator: MainOrchestrator = Depends(get_orches
             "total_actions": len(orchestrator.world_state.state.action_history.actions),
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting action history: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting action history")
+        raise HTTPException(status_code=500, detail="Unable to get action history")

--- a/chatbot/api_server/routers/setup.py
+++ b/chatbot/api_server/routers/setup.py
@@ -53,9 +53,9 @@ async def start_setup(setup_manager: SetupManager = Depends(get_setup_manager)):
                 "complete": True,
                 "step": None
             }
-    except Exception as e:
-        logger.error(f"Error starting setup: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error starting setup")
+        raise HTTPException(status_code=500, detail="Unable to start setup")
 
 
 @router.post("/submit")
@@ -67,9 +67,9 @@ async def submit_setup_step(
     try:
         result = setup_manager.submit_step(submission.step_key, submission.value)
         return result
-    except Exception as e:
-        logger.error(f"Error submitting setup step: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error submitting setup step")
+        raise HTTPException(status_code=500, detail="Unable to submit setup step")
 
 
 @router.post("/reset")
@@ -78,9 +78,9 @@ async def reset_setup(setup_manager: SetupManager = Depends(get_setup_manager)):
     try:
         setup_manager.reset_setup()
         return {"success": True, "message": "Setup process has been reset"}
-    except Exception as e:
-        logger.error(f"Error resetting setup: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error resetting setup")
+        raise HTTPException(status_code=500, detail="Unable to reset setup")
 
 
 @router.get("/status")
@@ -88,6 +88,6 @@ async def get_setup_status(setup_manager: SetupManager = Depends(get_setup_manag
     """Get the current setup status."""
     try:
         return setup_manager.get_setup_status()
-    except Exception as e:
-        logger.error(f"Error getting setup status: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting setup status")
+        raise HTTPException(status_code=500, detail="Unable to get setup status")

--- a/chatbot/api_server/routers/system.py
+++ b/chatbot/api_server/routers/system.py
@@ -65,9 +65,9 @@ async def get_system_status(orchestrator: MainOrchestrator = Depends(get_orchest
         try:
             integration_status = await orchestrator.integration_manager.list_integrations()
             logger.info(f"Got integration status: {type(integration_status)}")
-        except Exception as e:
-            logger.warning(f"Failed to get integration status: {e}")
-            integration_status = {"error": str(e)}
+        except Exception:
+            logger.warning("Failed to get integration status", exc_info=True)
+            integration_status = {"error": "Integration status unavailable"}
         
         logger.info("Assembling final status response")
         status = {
@@ -88,9 +88,9 @@ async def get_system_status(orchestrator: MainOrchestrator = Depends(get_orchest
         logger.info("get_system_status completed successfully")
         return status
         
-    except Exception as e:
-        logger.error(f"Error getting system status: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to get system status: {str(e)}")
+    except Exception:
+        logger.exception("Error getting system status")
+        raise HTTPException(status_code=500, detail="Failed to get system status")
 
 
 @router.post("/command", response_model=StatusResponse)
@@ -172,6 +172,8 @@ async def execute_system_command(
         else:
             raise HTTPException(status_code=400, detail=f"Unknown command: {command.command}")
             
-    except Exception as e:
-        logger.error(f"Error executing system command {command.command}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Command execution failed: {str(e)}")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Error executing system command %s", command.command)
+        raise HTTPException(status_code=500, detail="Command execution failed")

--- a/chatbot/api_server/routers/tools.py
+++ b/chatbot/api_server/routers/tools.py
@@ -44,9 +44,9 @@ async def get_tools(orchestrator: MainOrchestrator = Depends(get_orchestrator)):
             "stats": orchestrator.tool_registry.get_tool_stats()
         }
         
-    except Exception as e:
-        logger.error(f"Error getting tools: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to get tools: {str(e)}")
+    except Exception:
+        logger.exception("Error getting tools")
+        raise HTTPException(status_code=500, detail="Failed to get tools")
 
 
 @router.put("/{tool_name}/status", response_model=StatusResponse)
@@ -80,9 +80,9 @@ async def update_tool_status(
         
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error updating tool status for {tool_name}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to update tool status: {str(e)}")
+    except Exception:
+        logger.exception("Error updating tool status for %s", tool_name)
+        raise HTTPException(status_code=500, detail="Failed to update tool status")
 
 
 @router.get("/{tool_name}")
@@ -122,6 +122,6 @@ async def get_tool_details(
         
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error getting tool details for {tool_name}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to get tool details: {str(e)}")
+    except Exception:
+        logger.exception("Error getting tool details for %s", tool_name)
+        raise HTTPException(status_code=500, detail="Failed to get tool details")

--- a/chatbot/api_server/routers/ui_frames.py
+++ b/chatbot/api_server/routers/ui_frames.py
@@ -7,11 +7,14 @@ This module handles all UI serving and Farcaster frame endpoints including:
 - Frame actions and responses
 """
 
+import hashlib
+import hmac
+import html
+from pathlib import Path
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, HTTPException, Request, Depends
 from fastapi.responses import FileResponse, HTMLResponse
 from pydantic import BaseModel
-import os
 from datetime import datetime
 import logging
 
@@ -24,6 +27,7 @@ logger = logging.getLogger(__name__)
 # Create two routers - one for UI and one for frames
 ui_router = APIRouter(tags=["ui"])
 frames_router = APIRouter(prefix="/frames", tags=["frames"])
+UI_ROOT = (Path.cwd() / "ui").resolve()
 
 
 class FrameActionRequest(BaseModel):
@@ -32,13 +36,36 @@ class FrameActionRequest(BaseModel):
     trustedData: Dict[str, Any]
 
 
+def _ui_file(file_path: str) -> Optional[Path]:
+    candidate = (UI_ROOT / file_path).resolve()
+    if candidate.is_relative_to(UI_ROOT) and candidate.is_file():
+        return candidate
+    return None
+
+
+async def _verify_frame_signature(request: Request) -> None:
+    secret = settings.FRAMES_WEBHOOK_SECRET
+    if not secret or len(secret.encode("utf-8")) < 32:
+        raise HTTPException(
+            status_code=503, detail="Frame action verification is not configured"
+        )
+    supplied = request.headers.get("x-frame-signature", "")
+    if supplied.startswith("sha256="):
+        supplied = supplied[7:]
+    expected = hmac.new(
+        secret.encode("utf-8"), await request.body(), hashlib.sha256
+    ).hexdigest()
+    if not supplied or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(status_code=401, detail="Invalid frame signature")
+
+
 # ===== UI ENDPOINTS =====
 
 @ui_router.get("/")
 async def serve_root():
     """Redirect root to UI."""
-    ui_file = os.path.join(os.getcwd(), "ui", "index.html")
-    if os.path.exists(ui_file):
+    ui_file = _ui_file("index.html")
+    if ui_file:
         return FileResponse(ui_file)
     else:
         raise HTTPException(status_code=404, detail="UI not found. Please ensure ui/index.html exists.")
@@ -47,13 +74,13 @@ async def serve_root():
 @ui_router.get("/ui/{file_path:path}")
 async def serve_ui_files(file_path: str):
     """Serve UI static files."""
-    ui_path = os.path.join(os.getcwd(), "ui", file_path)
-    if os.path.exists(ui_path) and os.path.isfile(ui_path):
+    ui_path = _ui_file(file_path)
+    if ui_path:
         return FileResponse(ui_path)
     else:
         # Fallback to index.html for SPA routing
-        index_path = os.path.join(os.getcwd(), "ui", "index.html")
-        if os.path.exists(index_path):
+        index_path = _ui_file("index.html")
+        if index_path:
             return FileResponse(index_path)
         else:
             raise HTTPException(status_code=404, detail="File not found")
@@ -81,20 +108,31 @@ async def serve_mint_frame(
     """
     try:
         # Get frame metadata from world state
-        world_state = orchestrator.world_state_manager.get_state()
+        world_state = await orchestrator.world_state.get_state()
         frame_metadata = getattr(world_state, 'nft_frames', {}).get(frame_id)
         
         if not frame_metadata:
             raise HTTPException(status_code=404, detail="Frame not found")
         
         # Build frame HTML with meta tags
-        title = frame_metadata.get('title', 'AI Art NFT')
-        description = frame_metadata.get('description', 'Mint this AI-generated artwork as an NFT')
-        image_url = frame_metadata.get('image_url', '')
+        title = html.escape(str(frame_metadata.get('title', 'AI Art NFT')), quote=True)
+        description = html.escape(
+            str(
+                frame_metadata.get(
+                    'description', 'Mint this AI-generated artwork as an NFT'
+                )
+            ),
+            quote=True,
+        )
+        image_url = html.escape(str(frame_metadata.get('image_url', '')), quote=True)
         button_text = "Check Eligibility" if claim_type == "gated" else "Mint NFT"
         
         # Construct action URL
-        action_url = f"{settings.FRAMES_BASE_URL or 'https://yourbot.com'}/frames/action/mint/{frame_id}"
+        action_url = html.escape(
+            f"{settings.FRAMES_BASE_URL or 'https://yourbot.com'}/frames/action/mint/{frame_id}",
+            quote=True,
+        )
+        escaped_claim_type = html.escape(claim_type.title(), quote=True)
         
         html_content = f"""
 <!DOCTYPE html>
@@ -162,7 +200,7 @@ async def serve_mint_frame(
         <img src="{image_url}" alt="{title}" class="frame-image" />
         <h1>{title}</h1>
         <p>{description}</p>
-        <p><strong>Claim Type:</strong> {claim_type.title()}</p>
+        <p><strong>Claim Type:</strong> {escaped_claim_type}</p>
         <p><strong>Max Mints:</strong> {max_mints}</p>
         <button class="mint-button" onclick="alert('Use Farcaster to interact with this frame!')">{button_text}</button>
     </div>
@@ -172,14 +210,17 @@ async def serve_mint_frame(
         
         return HTMLResponse(content=html_content)
         
-    except Exception as e:
-        logger.error(f"Error serving mint frame: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Error serving mint frame")
+        raise HTTPException(status_code=500, detail="Unable to render frame")
 
 
 @frames_router.post("/action/mint/{frame_id}")
 async def handle_mint_action(
     frame_id: str,
+    request: Request,
     action_data: FrameActionRequest,
     orchestrator: MainOrchestrator = Depends(get_orchestrator)
 ):
@@ -189,11 +230,10 @@ async def handle_mint_action(
     This endpoint processes the Farcaster frame button click and returns
     appropriate response based on user eligibility and minting logic.
     """
+    await _verify_frame_signature(request)
     try:
         # Extract user data from the frame action
         untrusted_data = action_data.untrustedData
-        trusted_data = action_data.trustedData
-        
         # Get user's FID (Farcaster ID)
         user_fid = untrusted_data.get('fid')
         button_index = untrusted_data.get('buttonIndex', 1)
@@ -201,7 +241,7 @@ async def handle_mint_action(
         logger.info(f"Frame action for {frame_id} from user {user_fid}, button {button_index}")
         
         # Get frame metadata
-        world_state = orchestrator.world_state_manager.get_state()
+        world_state = await orchestrator.world_state.get_state()
         frame_metadata = getattr(world_state, 'nft_frames', {}).get(frame_id)
         
         if not frame_metadata:

--- a/chatbot/api_server/routers/worldstate.py
+++ b/chatbot/api_server/routers/worldstate.py
@@ -55,9 +55,9 @@ async def get_world_state(orchestrator: MainOrchestrator = Depends(get_orchestra
             "processing_mode": "node_based" if orchestrator.config.processing_config.enable_node_based_processing else "traditional",
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting world state: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting world state")
+        raise HTTPException(status_code=500, detail="Could not get world state")
 
 
 @router.get("/channels")
@@ -88,9 +88,9 @@ async def get_channels(orchestrator: MainOrchestrator = Depends(get_orchestrator
             "total_channels": len(channels),
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
-        logger.error(f"Error getting channels: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting channels")
+        raise HTTPException(status_code=500, detail="Could not get channels")
 
 
 @router.get("/ai-payload")
@@ -127,9 +127,11 @@ async def get_ai_world_state_payload(orchestrator: MainOrchestrator = Depends(ge
                 "timestamp": datetime.now().isoformat()
             }
         }
-    except Exception as e:
-        logger.error(f"Error getting AI world state payload: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("Error getting AI world state payload")
+        raise HTTPException(
+            status_code=500, detail="Could not build AI world state payload"
+        )
 
 
 @router.post("/node/action")
@@ -165,6 +167,8 @@ async def execute_node_action(
             "node_id": action.node_id,
             "message": f"Action '{action.action}' executed on node '{action.node_id}'"
         }
-    except Exception as e:
-        logger.error(f"Error executing node action: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Error executing node action")
+        raise HTTPException(status_code=500, detail="Could not execute node action")

--- a/chatbot/api_server/services/setup_manager.py
+++ b/chatbot/api_server/services/setup_manager.py
@@ -133,7 +133,7 @@ class SetupManager:
         """Save the configuration to a config file in the data directory."""
         # Use data directory for persistence instead of .env (which may be read-only in Docker)
         config_path = Path("data/config.json")
-        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         
         # Map our step keys to environment variable names
         step_to_env = {
@@ -156,8 +156,22 @@ class SetupManager:
         
         # Save to JSON file
         try:
-            with open(config_path, 'w') as f:
-                json.dump(config, f, indent=2)
+            temporary_path = config_path.with_suffix(".json.tmp")
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(temporary_path, flags, 0o600)
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "w") as config_file:
+                    descriptor = -1
+                    json.dump(config, config_file, indent=2)
+                    config_file.flush()
+                    os.fsync(config_file.fileno())
+                os.replace(temporary_path, config_path)
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
             logger.info(f"Configuration saved to {config_path}")
         except Exception as e:
             logger.error(f"Failed to save configuration: {e}")

--- a/chatbot/api_server/services/websocket_manager.py
+++ b/chatbot/api_server/services/websocket_manager.py
@@ -17,8 +17,8 @@ class LogWebSocketManager:
         self.active_connections: List[WebSocket] = []
         self.log_handler = None
         
-    async def connect(self, websocket: WebSocket):
-        await websocket.accept()
+    async def connect(self, websocket: WebSocket, subprotocol: str = None):
+        await websocket.accept(subprotocol=subprotocol)
         self.active_connections.append(websocket)
         
     def disconnect(self, websocket: WebSocket):

--- a/chatbot/config.py
+++ b/chatbot/config.py
@@ -38,6 +38,8 @@ class AppConfig(BaseSettings):
 
     # Chatbot Core
     CHATBOT_DB_PATH: str = "data/chatbot.db"
+    CHATBOT_ENV: str = "development"
+    INTEGRATION_CREDENTIAL_KEY: Optional[str] = None
     OBSERVATION_INTERVAL: float = 2.0
     MAX_CYCLES_PER_HOUR: int = 300
     MAX_ACTIONS_PER_HOUR: int = 600
@@ -58,6 +60,26 @@ class AppConfig(BaseSettings):
     )
     MATRIX_DEVICE_ID: Optional[str] = None
     MATRIX_MEDIA_GALLERY_ROOM_ID: Optional[str] = None  # Dedicated channel for auto-posting generated media
+
+    # Telegram
+    TELEGRAM_BOT_TOKEN: Optional[str] = None
+    TELEGRAM_ALLOWED_CHAT_IDS: str = ""
+    TELEGRAM_ALLOWED_SENDER_IDS: str = ""
+    TELEGRAM_MESSAGE_RATE_LIMIT_PER_MINUTE: int = 10
+    TELEGRAM_MAX_MESSAGE_CHARS: int = 4000
+    TELEGRAM_OFFSET_PATH: str = "data/telegram_offset.txt"
+    TELEGRAM_OPERATOR_QUEUE_PATH: str = "data/telegram_operator_queue.jsonl"
+    TELEGRAM_OPERATOR_QUEUE_MAX_BYTES: int = 1_048_576
+
+    # Local management API. The token is required for every /api request other
+    # than health checks and for the log WebSocket.
+    ADMIN_API_TOKEN: Optional[str] = None
+    ADMIN_API_HOST: str = "127.0.0.1"
+    ADMIN_API_PORT: int = 8000
+    ADMIN_API_ALLOWED_ORIGINS: str = (
+        "http://127.0.0.1:8000,http://localhost:8000,http://localhost:3000"
+    )
+    INTEGRATION_CONNECT_TIMEOUT_SECONDS: float = 15.0
     DEVICE_NAME: str = "ratichat_bot"
 
     # Farcaster (Optional)
@@ -65,6 +87,7 @@ class AppConfig(BaseSettings):
     FARCASTER_BOT_FID: Optional[str] = None
     FARCASTER_BOT_SIGNER_UUID: Optional[str] = None
     FARCASTER_BOT_USERNAME: Optional[str] = None  # Bot's username for filtering
+    FARCASTER_WEBHOOK_SECRET: Optional[str] = None
 
     # Ecosystem Token Tracking
     ECOSYSTEM_TOKEN_CONTRACT_ADDRESS: Optional[str] = "Ci6Y1UX8bY4jxn6YiogJmdCxFEu2jmZhCcG65PStpump"  # Contract address of the token
@@ -114,6 +137,7 @@ class AppConfig(BaseSettings):
     # Arweave Configuration (Internal Uploader Service)
     ARWEAVE_INTERNAL_UPLOADER_SERVICE_URL: str = "http://arweave-uploader:8001"
     ARWEAVE_GATEWAY_URL: str = "https://arweave.net"
+    ARWEAVE_UPLOADER_API_KEY: Optional[str] = None
 
     # NFT & Airdrop Configuration (v0.0.4)
     NFT_DEV_WALLET_PRIVATE_KEY: Optional[str] = None  # For sponsoring transactions or direct minting

--- a/chatbot/core/integration_manager.py
+++ b/chatbot/core/integration_manager.py
@@ -39,9 +39,15 @@ class IntegrationManager:
         if encryption_key:
             self.cipher = Fernet(encryption_key)
         else:
-            # Generate a key for development - in production, this should come from a secure vault
+            if settings.CHATBOT_ENV.lower() == "production":
+                raise ValueError(
+                    "INTEGRATION_CREDENTIAL_KEY is required in production"
+                )
+            # Ephemeral credentials are acceptable only for local/test databases.
             self.cipher = Fernet(Fernet.generate_key())
-            logger.warning("Using generated encryption key - not suitable for production!")
+            logger.warning(
+                "Using an ephemeral integration credential key in non-production"
+            )
             
     async def initialize(self):
         """Initialize the integration manager and database schema"""
@@ -155,7 +161,7 @@ class IntegrationManager:
             self.integration_types['farcaster'] = FarcasterObserver
         except ImportError as e:
             logger.warning(f"Failed to import FarcasterObserver: {e}")
-            
+
         logger.info(f"Registered integration types: {list(self.integration_types.keys())}")
         
     async def add_integration(
@@ -244,6 +250,9 @@ class IntegrationManager:
         # Create integration instance
         integration_class = self.integration_types[integration_data['integration_type']]
         config = json.loads(integration_data['config'])
+        if config.get("test_mode") is True:
+            logger.info("Skipped network connection for test-mode integration %s", integration_id)
+            return False
         
         # Load credentials for this integration
         credentials = await self._load_credentials(integration_id)
@@ -280,12 +289,22 @@ class IntegrationManager:
         
         # Attempt connection
         try:
-            await integration.connect()
+            await asyncio.wait_for(
+                integration.connect(),
+                timeout=settings.INTEGRATION_CONNECT_TIMEOUT_SECONDS,
+            )
             self.active_integrations[integration_id] = integration
             logger.info(f"Successfully connected integration {integration_id}")
             return True
         except Exception as e:
             logger.error(f"Error connecting integration {integration_id}: {e}")
+            try:
+                await asyncio.wait_for(integration.disconnect(), timeout=5)
+            except Exception:
+                logger.warning(
+                    "Cleanup failed for integration %s after connection failure",
+                    integration_id,
+                )
             return False
             
     async def disconnect_integration(self, integration_id: str) -> None:
@@ -295,6 +314,30 @@ class IntegrationManager:
             await integration.disconnect()
             del self.active_integrations[integration_id]
             logger.info(f"Disconnected integration {integration_id}")
+
+    async def remove_integration(self, integration_id: str) -> bool:
+        """Disconnect and permanently remove an integration and its credentials."""
+        await self.disconnect_integration(integration_id)
+
+        async def db_operation(db):
+            cursor = await db.execute(
+                "SELECT 1 FROM integrations WHERE id = ?", (integration_id,)
+            )
+            if await cursor.fetchone() is None:
+                return False
+            await db.execute(
+                "DELETE FROM credentials WHERE integration_id = ?", (integration_id,)
+            )
+            await db.execute(
+                "DELETE FROM integrations WHERE id = ?", (integration_id,)
+            )
+            await db.commit()
+            return True
+
+        removed = await self._execute_db_operation(db_operation)
+        if removed:
+            logger.info("Removed integration %s", integration_id)
+        return removed
             
     async def connect_all_active(self) -> Dict[str, bool]:
         """
@@ -379,7 +422,13 @@ class IntegrationManager:
         """
         if integration_type not in self.integration_types:
             return {"success": False, "error": f"Unsupported integration type: {integration_type}"}
+        if config.get("test_mode") is True:
+            return {
+                "success": False,
+                "error": "Network connection tests are disabled in test mode",
+            }
             
+        integration = None
         try:
             # Create temporary integration instance
             integration_class = self.integration_types[integration_type]
@@ -399,11 +448,21 @@ class IntegrationManager:
             if hasattr(integration, 'set_credentials'):
                 await integration.set_credentials(credentials)
                 
-            result = await integration.test_connection()
+            result = await asyncio.wait_for(
+                integration.test_connection(),
+                timeout=settings.INTEGRATION_CONNECT_TIMEOUT_SECONDS,
+            )
             return {"success": result, "error": None if result else "Connection test failed"}
             
-        except Exception as e:
-            return {"success": False, "error": str(e)}
+        except Exception:
+            logger.exception("Integration connection test failed")
+            return {"success": False, "error": "Connection test failed"}
+        finally:
+            if integration is not None:
+                try:
+                    await asyncio.wait_for(integration.disconnect(), timeout=5)
+                except Exception:
+                    logger.warning("Integration test cleanup failed")
             
     async def _load_integration_data(self, integration_id: str) -> Optional[Dict[str, Any]]:
         """Load integration configuration from database"""

--- a/chatbot/core/orchestration/main_orchestrator.py
+++ b/chatbot/core/orchestration/main_orchestrator.py
@@ -21,6 +21,8 @@ from ...integrations.arweave_uploader_client import ArweaveUploaderClient
 from ...integrations.farcaster import FarcasterObserver
 from ..node_system.node_manager import NodeManager
 from ...integrations.matrix.observer import MatrixObserver
+from ...integrations.telegram import TelegramObserver
+from ...integrations.telegram.operator_queue import OperatorQueueBridge
 from ...integrations.base_nft_service import BaseNFTService
 from ...integrations.eligibility_service import UserEligibilityService
 from ...tools.registry import ToolRegistry
@@ -230,6 +232,11 @@ class MainOrchestrator:
         # Integration management
         self.integration_manager = IntegrationManager(
             db_path=self.config.db_path,
+            encryption_key=(
+                settings.INTEGRATION_CREDENTIAL_KEY.encode("utf-8")
+                if settings.INTEGRATION_CREDENTIAL_KEY
+                else None
+            ),
             world_state_manager=self.world_state
         )
         
@@ -263,6 +270,7 @@ class MainOrchestrator:
             self.arweave_client = ArweaveUploaderClient(
                 uploader_service_url=settings.ARWEAVE_INTERNAL_UPLOADER_SERVICE_URL,
                 gateway_url=settings.ARWEAVE_GATEWAY_URL,
+                api_key=settings.ARWEAVE_UPLOADER_API_KEY,
             )
             logger.info("Arweave client initialized for internal uploader service.")
         
@@ -283,6 +291,7 @@ class MainOrchestrator:
         # External observers
         self.matrix_observer: Optional[MatrixObserver] = None
         self.farcaster_observer: Optional[FarcasterObserver] = None
+        self.telegram_observer: Optional[TelegramObserver] = None
         
         # NFT and eligibility services
         self.base_nft_service: Optional[BaseNFTService] = None
@@ -324,6 +333,7 @@ class MainOrchestrator:
             CreateMintFrameTool,
             CreateAirdropClaimFrameTool,
         )
+        from ...tools.telegram_tools import SendTelegramMessageTool, SendTelegramReplyTool
         from ...tools.matrix_tools import (
             AcceptMatrixInviteTool,
             IgnoreMatrixInviteTool,
@@ -335,7 +345,13 @@ class MainOrchestrator:
             SendMatrixReplyTool,
             SendMatrixVideoTool,
         )
-        from ...tools.media_generation_tools import GenerateImageTool, GenerateVideoTool
+        try:
+            from ...tools.media_generation_tools import GenerateImageTool, GenerateVideoTool
+            _has_media_tools = True
+        except ImportError:
+            GenerateImageTool = GenerateVideoTool = None
+            _has_media_tools = False
+            logger.warning("Media generation tools unavailable — skipping")
         from ...tools.permaweb_tools import StorePermanentMemoryTool
         from ...tools.web_tools import WebSearchTool
         from ...tools.research_tools import UpdateResearchTool, QueryResearchTool
@@ -378,6 +394,10 @@ class MainOrchestrator:
         self.tool_registry.register_tool(AcceptMatrixInviteTool())
         self.tool_registry.register_tool(IgnoreMatrixInviteTool())
         
+        # Telegram tools
+        self.tool_registry.register_tool(SendTelegramMessageTool())
+        self.tool_registry.register_tool(SendTelegramReplyTool())
+
         # Farcaster tools
         self.tool_registry.register_tool(SendFarcasterPostTool())
         self.tool_registry.register_tool(SendFarcasterReplyTool())
@@ -406,8 +426,9 @@ class MainOrchestrator:
         self.tool_registry.register_tool(CreateAirdropClaimFrameTool())
         
         # Media generation tools
-        self.tool_registry.register_tool(GenerateImageTool())
-        self.tool_registry.register_tool(GenerateVideoTool())
+        if _has_media_tools:
+            self.tool_registry.register_tool(GenerateImageTool())
+            self.tool_registry.register_tool(GenerateVideoTool())
         
         # Permaweb tools
         self.tool_registry.register_tool(StorePermanentMemoryTool())
@@ -516,6 +537,12 @@ class MainOrchestrator:
         if self.farcaster_observer:
             await self.farcaster_observer.stop()
 
+        if self.telegram_observer:
+            await self.telegram_observer.stop()
+
+        if hasattr(self, "telegram_operator_queue") and self.telegram_operator_queue:
+            await self.telegram_operator_queue.stop()
+
         logger.info("Main orchestrator system stopped")
 
     def _setup_processing_components(self):
@@ -622,10 +649,39 @@ class MainOrchestrator:
             except Exception as e:
                 logger.error(f"Failed to initialize Farcaster observer: {e}")
                 logger.info("Continuing without Farcaster integration")
-        
+
+        # Initialize Telegram observer if token available
+        if settings.TELEGRAM_BOT_TOKEN:
+            try:
+                self.telegram_observer = TelegramObserver(
+                    world_state_manager=self.world_state
+                )
+                await self.telegram_observer.start()
+                self.telegram_operator_queue = OperatorQueueBridge(
+                    self.telegram_observer
+                )
+                self.telegram_observer.operator_queue_bridge = (
+                    self.telegram_operator_queue
+                )
+                await self.telegram_operator_queue.start()
+                self.world_state.update_system_status(
+                    {"telegram_connected": True}
+                )
+                logger.info("Telegram observer initialized and started")
+            except Exception as e:
+                logger.error(f"Failed to initialize Telegram observer: {e}")
+                if getattr(self, "telegram_operator_queue", None):
+                    await self.telegram_operator_queue.stop()
+                    self.telegram_operator_queue = None
+                if self.telegram_observer:
+                    await self.telegram_observer.stop()
+                    self.telegram_observer = None
+                logger.info("Continuing without Telegram integration")
+
         # Update action context with initialized observers
         self.action_context.matrix_observer = self.matrix_observer
         self.action_context.farcaster_observer = self.farcaster_observer
+        self.action_context.telegram_observer = self.telegram_observer
         
         # Configure critical node pinning based on active integrations
         self._configure_critical_node_pinning()

--- a/chatbot/integrations/farcaster/webhook_handler.py
+++ b/chatbot/integrations/farcaster/webhook_handler.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import HTTPException, Request
 
+from ...config import settings
 from ...core.world_state import WorldStateManager
 
 logger = logging.getLogger(__name__)
@@ -22,10 +23,12 @@ class FarcasterWebhookHandler:
 
     def __init__(self, world_state_manager: WorldStateManager):
         self.world_state = world_state_manager
-        self.webhook_secret: Optional[str] = None  # For verifying webhook authenticity
+        self.webhook_secret = settings.FARCASTER_WEBHOOK_SECRET
 
     def set_webhook_secret(self, secret: str):
         """Set the webhook secret for verification"""
+        if len(secret.encode("utf-8")) < 32:
+            raise ValueError("Farcaster webhook secret must be at least 32 bytes")
         self.webhook_secret = secret
 
     async def handle_webhook(self, request: Request) -> Dict[str, str]:
@@ -45,16 +48,23 @@ class FarcasterWebhookHandler:
             # Get raw body for signature verification
             body = await request.body()
             headers = request.headers
-            
-            # Verify webhook signature if secret is configured
-            if self.webhook_secret:
-                await self._verify_webhook_signature(body, headers)
+            if len(body) > 1_048_576:
+                raise HTTPException(status_code=413, detail="Webhook payload too large")
+            if not self.webhook_secret or len(
+                self.webhook_secret.encode("utf-8")
+            ) < 32:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Farcaster webhook verification is not configured",
+                )
+            await self._verify_webhook_signature(body, headers)
             
             # Parse JSON payload
             try:
                 payload = json.loads(body.decode('utf-8'))
-            except json.JSONDecodeError as e:
-                logger.error(f"Invalid JSON in webhook payload: {e}")
+                if not isinstance(payload, dict):
+                    raise ValueError("Webhook payload must be an object")
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
                 raise HTTPException(status_code=400, detail="Invalid JSON payload")
             
             # Process the webhook event
@@ -114,25 +124,23 @@ class FarcasterWebhookHandler:
         """
         event_type = payload.get('type')
         data = payload.get('data', {})
+        if not isinstance(event_type, str) or not isinstance(data, dict):
+            raise HTTPException(status_code=400, detail="Invalid webhook payload")
         
         logger.info(f"Processing Farcaster webhook event: {event_type}")
         
-        try:
-            if event_type == 'cast.created':
-                await self._handle_cast_created(data)
-            elif event_type == 'cast.mention':
-                await self._handle_mention(data)
-            elif event_type == 'reaction.created':
-                await self._handle_reaction_created(data)
-            elif event_type == 'follow.created':
-                await self._handle_follow_created(data)
-            elif event_type == 'cast.reply':
-                await self._handle_cast_reply(data)
-            else:
-                logger.info(f"Unhandled webhook event type: {event_type}")
-                
-        except Exception as e:
-            logger.error(f"Error processing webhook event {event_type}: {e}")
+        if event_type == 'cast.created':
+            await self._handle_cast_created(data)
+        elif event_type == 'cast.mention':
+            await self._handle_mention(data)
+        elif event_type == 'reaction.created':
+            await self._handle_reaction_created(data)
+        elif event_type == 'follow.created':
+            await self._handle_follow_created(data)
+        elif event_type == 'cast.reply':
+            await self._handle_cast_reply(data)
+        else:
+            logger.info(f"Unhandled webhook event type: {event_type}")
 
     async def _handle_cast_created(self, data: Dict[str, Any]):
         """Handle new cast creation event"""

--- a/chatbot/integrations/google_ai_media_client.py
+++ b/chatbot/integrations/google_ai_media_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import base64
 import io
@@ -7,9 +9,21 @@ import time # Kept for Veo polling timeout
 from typing import Dict, List, Optional, Union # Kept for type hints
 
 import httpx # Kept for Veo video downloads if URI is returned by SDK
-from google import genai
-from google.genai import types
-from PIL import Image # For handling image data
+
+try:
+    from google import genai
+    from google.genai import types
+except ImportError as exc:
+    genai = None
+    types = None
+    _GENAI_IMPORT_ERROR = exc
+else:
+    _GENAI_IMPORT_ERROR = None
+
+try:
+    from PIL import Image # For handling image data
+except ImportError:
+    Image = None
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +50,10 @@ class GoogleAIMediaClient:
             default_veo_video_model: Default Veo model for video generation.
         """
         self.api_key = api_key
+        if genai is None or types is None:
+            raise RuntimeError(
+                "Google AI media support requires the locked google-genai dependency"
+            ) from _GENAI_IMPORT_ERROR
         try:
             # Initialize the google-genai client for Gemini Developer API
             self.client = genai.Client(api_key=self.api_key)

--- a/chatbot/integrations/telegram/__init__.py
+++ b/chatbot/integrations/telegram/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram integration for ratichat — observe messages and send replies."""
+
+from .observer import TelegramObserver
+
+__all__ = ["TelegramObserver"]

--- a/chatbot/integrations/telegram/observer.py
+++ b/chatbot/integrations/telegram/observer.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+Telegram Observer
+
+Accepts authorized Telegram messages into a local operator-review queue.
+Follows the same Integration pattern as the Matrix observer.
+Uses raw httpx against the Telegram Bot API (no heavy framework dependency).
+"""
+
+import asyncio
+import logging
+import os
+import time
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any, Deque, Dict, Optional
+
+import httpx
+
+from ...config import settings
+from ...core.world_state import WorldStateManager
+from ..base import Integration, IntegrationConnectionError
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API = "https://api.telegram.org"
+
+
+def parse_id_allowlist(raw_value: str) -> frozenset[str]:
+    """Parse a comma-separated ID allowlist, ignoring empty entries."""
+    return frozenset(value.strip() for value in raw_value.split(",") if value.strip())
+
+
+class MessageRateLimiter:
+    """Small in-memory sliding-window limiter keyed by authorized sender."""
+
+    def __init__(self, limit_per_minute: int):
+        if limit_per_minute < 1:
+            raise ValueError("Telegram rate limit must be at least one message per minute")
+        self.limit = limit_per_minute
+        self._events: Dict[str, Deque[float]] = defaultdict(deque)
+
+    def allow(self, key: str, now: Optional[float] = None) -> bool:
+        current = time.monotonic() if now is None else now
+        events = self._events[key]
+        cutoff = current - 60.0
+        while events and events[0] <= cutoff:
+            events.popleft()
+        if len(events) >= self.limit:
+            return False
+        events.append(current)
+        return True
+
+
+class TelegramObserver(Integration):
+    """Observes Telegram chats and reports to world state."""
+
+    def __init__(
+        self,
+        integration_id: str = "telegram",
+        display_name: str = "Telegram Integration",
+        config: Dict[str, Any] = None,
+        world_state_manager: WorldStateManager = None,
+    ):
+        # Support legacy positional usage
+        if not isinstance(integration_id, str) and world_state_manager is None:
+            world_state_manager = integration_id
+            integration_id = "telegram"
+            display_name = "Telegram Integration"
+            config = config or {}
+
+        super().__init__(integration_id, display_name, config or {})
+        self.world_state = world_state_manager
+        self.operator_queue_bridge = None  # set by orchestrator after init
+        self.token = settings.TELEGRAM_BOT_TOKEN
+        self.allowed_chat_ids = parse_id_allowlist(settings.TELEGRAM_ALLOWED_CHAT_IDS)
+        self.allowed_sender_ids = parse_id_allowlist(
+            settings.TELEGRAM_ALLOWED_SENDER_IDS
+        )
+        self.max_message_chars = settings.TELEGRAM_MAX_MESSAGE_CHARS
+        if self.max_message_chars < 1 or self.max_message_chars > 4096:
+            raise ValueError("TELEGRAM_MAX_MESSAGE_CHARS must be between 1 and 4096")
+        self._rate_limiter = MessageRateLimiter(
+            settings.TELEGRAM_MESSAGE_RATE_LIMIT_PER_MINUTE
+        )
+        self._http: Optional[httpx.AsyncClient] = None
+        self._poll_task: Optional[asyncio.Task] = None
+        self._offset: int = 0
+        self._connected = False
+        self._bot_username: Optional[str] = None
+        self._offset_file = Path(settings.TELEGRAM_OFFSET_PATH).expanduser()
+
+        # Check configuration
+        self._replied_ids: set[str] = set()  # dedup sent replies
+        self._enabled = bool(
+            self.token and self.allowed_chat_ids and self.allowed_sender_ids
+        )
+        if not self._enabled:
+            logger.warning(
+                "Telegram disabled: token plus non-empty chat and sender allowlists "
+                "are required"
+            )
+            return
+
+        logger.info("TelegramObserver: Initialized")
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def integration_type(self) -> str:
+        return "telegram"
+
+    # ── Integration interface ────────────────────────────────────────────
+
+    async def connect(self) -> None:
+        if not self.enabled:
+            raise IntegrationConnectionError(
+                "Telegram observer is disabled by incomplete authorization settings"
+            )
+
+        logger.info("TelegramObserver: Connecting…")
+        self._http = httpx.AsyncClient(timeout=30.0)
+        try:
+            self._load_offset()
+            me = await self._api("getMe")
+            if not me.get("ok"):
+                raise IntegrationConnectionError(
+                    f"Telegram getMe failed: {me.get('description', 'unknown')}"
+                )
+        except Exception:
+            await self._http.aclose()
+            self._http = None
+            raise
+        self._bot_username = me["result"]["username"]
+        logger.info(f"TelegramObserver: Connected as @{self._bot_username}")
+
+        # Update world state
+        if self.world_state:
+            self.world_state.update_system_status({"telegram_connected": True})
+
+        self._connected = True
+
+        # Start polling
+        self._poll_task = asyncio.create_task(self._poll_forever())
+        logger.info("TelegramObserver: Polling started")
+
+    async def disconnect(self) -> None:
+        if not self.enabled:
+            return
+
+        logger.info("TelegramObserver: Disconnecting…")
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+            self._poll_task = None
+
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+        if self.world_state:
+            self.world_state.update_system_status({"telegram_connected": False})
+
+        self._connected = False
+        logger.info("TelegramObserver: Disconnected")
+
+    async def get_status(self) -> Dict[str, Any]:
+        if not self.enabled:
+            return {
+                "connected": False,
+                "enabled": False,
+                "error": "Missing Telegram token or authorization allowlist",
+            }
+
+        return {
+            "connected": self._connected,
+            "enabled": self.enabled,
+            "bot_username": self._bot_username,
+            "poll_offset": self._offset,
+        }
+
+    async def test_connection(self) -> bool:
+        if not self.enabled:
+            return False
+        try:
+            resp = await self._api("getMe")
+            return resp.get("ok", False)
+        except Exception:
+            return False
+
+    # Legacy compat
+    async def start(self):
+        await self.connect()
+
+    async def stop(self):
+        await self.disconnect()
+
+    # ── API helpers ──────────────────────────────────────────────────────
+
+    async def _api(self, method: str, data: dict = None) -> dict:
+        url = f"{TELEGRAM_API}/bot{self.token}/{method}"
+        resp = await self._http.post(url, json=data or {})
+        resp.raise_for_status()
+        return resp.json()
+
+    def _load_offset(self):
+        try:
+            self._offset = int(self._offset_file.read_text().strip())
+            if self._offset < 0:
+                raise ValueError("Telegram offset must not be negative")
+        except (OSError, ValueError):
+            self._offset = 0
+
+    def _save_offset(self):
+        self._offset_file.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        temporary_path = self._offset_file.with_suffix(".tmp")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(temporary_path, flags, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            os.write(descriptor, str(self._offset).encode("ascii"))
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary_path, self._offset_file)
+
+    # ── Polling loop ─────────────────────────────────────────────────────
+
+    async def _poll_forever(self):
+        """Long-poll Telegram for new messages."""
+        while True:
+            try:
+                result = await self._api("getUpdates", {
+                    "offset": self._offset,
+                    "timeout": 25,
+                    "allowed_updates": ["message"],
+                })
+
+                if not result.get("ok"):
+                    logger.warning(f"Telegram poll error: {result.get('description')}")
+                    await asyncio.sleep(5)
+                    continue
+
+                for upd in result.get("result", []):
+                    msg = upd.get("message")
+                    if msg:
+                        await self._handle_message(msg)
+                    self._offset = upd["update_id"] + 1
+                    self._save_offset()
+
+                # Periodic dedup cleanup (keep last 5 min of IDs)
+                if len(self._replied_ids) > 100:
+                    self._replied_ids.clear()
+                await asyncio.sleep(0.5)
+
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # httpx exceptions can include the request URL, which contains
+                # the Telegram bot token. Never render them into logs.
+                logger.error("Telegram polling failed; retrying")
+                await asyncio.sleep(5)
+
+    # ── Message handling ─────────────────────────────────────────────────
+
+    async def _handle_message(self, msg: dict):
+        """Process an incoming Telegram message into world state."""
+        chat = msg.get("chat", {})
+        sender = msg.get("from", {})
+        chat_id = str(chat.get("id", ""))
+        sender_id = str(sender.get("id", ""))
+
+        if (
+            chat_id not in self.allowed_chat_ids
+            or sender_id not in self.allowed_sender_ids
+        ):
+            logger.warning(
+                "Telegram rejected unauthorized message chat_id=%s sender_id=%s",
+                chat_id,
+                sender_id,
+            )
+            return
+
+        text = msg.get("text", "") or msg.get("caption", "")
+        if not text:
+            logger.info("Telegram ignored a non-text message from an authorized sender")
+            return
+        if len(text) > self.max_message_chars:
+            await self.send_message(
+                chat_id,
+                f"Message exceeds the {self.max_message_chars}-character limit.",
+                str(msg.get("message_id", "")) or None,
+            )
+            return
+        if not self._rate_limiter.allow(f"{chat_id}:{sender_id}"):
+            await self.send_message(
+                chat_id,
+                "Rate limit exceeded. Try again later.",
+                str(msg.get("message_id", "")) or None,
+            )
+            return
+
+        # Telegram is only an intake transport. A separately authenticated
+        # operator decides whether queued requests become implementation work.
+        if self.operator_queue_bridge:
+            await self.operator_queue_bridge.handle_message(
+                chat_id,
+                str(msg.get("message_id", "")),
+                sender_id,
+                text,
+            )
+        else:
+            raise RuntimeError("Telegram operator queue is unavailable")
+        logger.info(
+            "Telegram accepted message chat_id=%s sender_id=%s", chat_id, sender_id
+        )
+
+    # ── Sending ──────────────────────────────────────────────────────────
+
+    async def send_message(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to_message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Send a text message to a Telegram chat."""
+        if not self._http:
+            return {"success": False, "error": "Not connected"}
+        if chat_id not in self.allowed_chat_ids:
+            logger.warning("Telegram blocked outbound message to unauthorized chat")
+            return {"success": False, "error": "Unauthorized chat"}
+        if not text or len(text) > 4096:
+            return {"success": False, "error": "Invalid message length"}
+
+        # Dedup: one reply per (chat, msg_id)
+        dedup_key = f"{chat_id}:{reply_to_message_id}" if reply_to_message_id else None
+        if dedup_key and dedup_key in self._replied_ids:
+            logger.info(f"TelegramObserver: DEDUP skipped {dedup_key}")
+            return {"success": True, "message_id": None, "duplicate": True}
+
+        data: dict = {"chat_id": int(chat_id), "text": text}
+        if reply_to_message_id:
+            data["reply_to_message_id"] = int(reply_to_message_id)
+
+        try:
+            result = await self._api("sendMessage", data)
+            if result.get("ok"):
+                if dedup_key:
+                    self._replied_ids.add(dedup_key)
+                logger.info(f"TelegramObserver: Sent to {chat_id}")
+                return {"success": True, "message_id": result["result"]["message_id"]}
+            return {"success": False, "error": result.get("description", "unknown")}
+        except Exception:
+            logger.error("Telegram send failed")
+            return {"success": False, "error": "Telegram request failed"}
+
+    async def send_typing(self, chat_id: str):
+        """Send typing indicator."""
+        if self._http:
+            try:
+                await self._api("sendChatAction", {
+                    "chat_id": int(chat_id),
+                    "action": "typing",
+                })
+            except Exception:
+                pass

--- a/chatbot/integrations/telegram/operator_queue.py
+++ b/chatbot/integrations/telegram/operator_queue.py
@@ -1,0 +1,124 @@
+"""Local operator-review queue for authorized Telegram messages.
+
+This module intentionally does not execute an agent, a shell, or any worker.
+Telegram is an untrusted transport; converting a chat message directly into an
+agent prompt would turn the bot token into remote-code-execution authority.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import stat
+import time
+from pathlib import Path
+
+from ...config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class OperatorQueueBridge:
+    """Persist bounded requests for a separately authenticated operator."""
+
+    def __init__(self, telegram_observer):
+        self.observer = telegram_observer
+        self.queue_path = Path(settings.TELEGRAM_OPERATOR_QUEUE_PATH).expanduser()
+        self.max_queue_bytes = max(1, settings.TELEGRAM_OPERATOR_QUEUE_MAX_BYTES)
+        self._write_lock = asyncio.Lock()
+        self._queued_ids: set[str] = set()
+        self._running = False
+
+    async def start(self) -> None:
+        self.queue_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.queue_path.parent, 0o700)
+        if self.queue_path.is_symlink():
+            raise RuntimeError("Telegram operator queue must not be a symlink")
+        if self.queue_path.exists() and not self.queue_path.is_file():
+            raise RuntimeError("Telegram operator queue must be a regular file")
+        if self.queue_path.exists():
+            os.chmod(self.queue_path, 0o600)
+        self._load_queued_ids()
+        self._running = True
+        logger.info("Telegram operator-review queue started")
+
+    async def stop(self) -> None:
+        self._running = False
+        logger.info("Telegram operator-review queue stopped")
+
+    async def handle_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        sender_id: str,
+        text: str,
+    ) -> None:
+        """Queue one already-authorized message and acknowledge receipt."""
+        if not self._running:
+            raise RuntimeError("Telegram operator queue is not running")
+
+        entry = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "sender_id": sender_id,
+            "text": text,
+            "received_at": int(time.time()),
+        }
+        encoded = (json.dumps(entry, ensure_ascii=False) + "\n").encode("utf-8")
+        message_key = f"{chat_id}:{message_id}"
+
+        queued = await self._append_bounded(message_key, encoded)
+        response = (
+            "Request queued for authenticated operator review."
+            if queued
+            else "Operator queue is full. Try again later."
+        )
+        await self.observer.send_message(chat_id, response, message_id)
+
+    def _load_queued_ids(self) -> None:
+        self._queued_ids.clear()
+        if not self.queue_path.exists():
+            return
+        if self.queue_path.stat().st_size > self.max_queue_bytes:
+            raise RuntimeError("Telegram operator queue exceeds its configured limit")
+        for line in self.queue_path.read_text(encoding="utf-8").splitlines():
+            try:
+                entry = json.loads(line)
+                self._queued_ids.add(
+                    f"{entry['chat_id']}:{entry['message_id']}"
+                )
+            except (KeyError, TypeError, json.JSONDecodeError):
+                raise RuntimeError("Telegram operator queue contains invalid data")
+
+    async def _append_bounded(self, message_key: str, encoded: bytes) -> bool:
+        async with self._write_lock:
+            if message_key in self._queued_ids:
+                return True
+            current_size = (
+                self.queue_path.stat().st_size if self.queue_path.exists() else 0
+            )
+            if current_size + len(encoded) > self.max_queue_bytes:
+                logger.warning(
+                    "Telegram operator queue rejected a message because it is full"
+                )
+                return False
+
+            flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(self.queue_path, flags, 0o600)
+            try:
+                os.fchmod(fd, 0o600)
+                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    raise RuntimeError("Telegram operator queue is not a regular file")
+                remaining = memoryview(encoded)
+                while remaining:
+                    written = os.write(fd, remaining)
+                    if written < 1:
+                        raise OSError("Could not append to Telegram operator queue")
+                    remaining = remaining[written:]
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            self._queued_ids.add(message_key)
+            return True

--- a/chatbot/main_with_ui.py
+++ b/chatbot/main_with_ui.py
@@ -73,8 +73,8 @@ class ChatbotWithUI:
         def run_server():
             config = uvicorn.Config(
                 self.api_server,
-                host="0.0.0.0",
-                port=8000,
+                host=settings.ADMIN_API_HOST,
+                port=settings.ADMIN_API_PORT,
                 log_level="info"
             )
             server = uvicorn.Server(config)
@@ -82,8 +82,16 @@ class ChatbotWithUI:
             
         self.server_thread = Thread(target=run_server, daemon=True)
         self.server_thread.start()
-        logger.info("API server started on http://0.0.0.0:8000")
-        logger.info("Management UI available at http://localhost:8000")
+        logger.info(
+            "API server started on http://%s:%s",
+            settings.ADMIN_API_HOST,
+            settings.ADMIN_API_PORT,
+        )
+        logger.info(
+            "Management UI available at http://%s:%s",
+            settings.ADMIN_API_HOST,
+            settings.ADMIN_API_PORT,
+        )
         
     async def start_chatbot(self):
         """Start the chatbot orchestrator."""
@@ -128,9 +136,11 @@ class ChatbotWithUI:
             logger.info("=" * 60)
             logger.info("Chatbot Management Console is now running:")
             logger.info("  - Chatbot: Active and processing")
-            logger.info("  - API Server: http://localhost:8000")
-            logger.info("  - Management UI: http://localhost:8000")
-            logger.info("  - API Documentation: http://localhost:8000/docs")
+            logger.info(
+                "  - API Server: http://%s:%s",
+                settings.ADMIN_API_HOST,
+                settings.ADMIN_API_PORT,
+            )
             logger.info("=" * 60)
             
             # Keep running until signal received

--- a/chatbot/tools/telegram_tools.py
+++ b/chatbot/tools/telegram_tools.py
@@ -1,0 +1,100 @@
+"""
+Telegram platform-specific tools for ratichat.
+"""
+import logging
+import time
+from typing import Any, Dict
+
+from .base import ActionContext, ToolInterface
+
+logger = logging.getLogger(__name__)
+
+
+class SendTelegramMessageTool(ToolInterface):
+    """Send a message to a Telegram chat."""
+
+    @property
+    def name(self) -> str:
+        return "send_telegram_message"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Send a text message to a Telegram chat. Use this to respond to users "
+            "who messaged you on Telegram. The chat_id comes from the message's channel_id."
+        )
+
+    @property
+    def parameters_schema(self) -> Dict[str, Any]:
+        return {
+            "chat_id": "string (Telegram chat ID) — the chat to send to",
+            "content": "string — the message text to send",
+            "reply_to_id": "string (optional) — message ID to reply to",
+        }
+
+    async def execute(
+        self, params: Dict[str, Any], context: ActionContext
+    ) -> Dict[str, Any]:
+        logger.info("Executing Telegram message tool")
+
+        observer = getattr(context, "telegram_observer", None)
+        if not observer:
+            return {"status": "failure", "error": "Telegram observer not connected", "timestamp": time.time()}
+
+        chat_id = params.get("chat_id")
+        content = params.get("content")
+        reply_to = params.get("reply_to_id")
+
+        if not chat_id:
+            return {"status": "failure", "error": "Missing chat_id", "timestamp": time.time()}
+        if not content:
+            return {"status": "failure", "error": "Missing content", "timestamp": time.time()}
+
+        result = await observer.send_message(str(chat_id), str(content), str(reply_to) if reply_to else None)
+        if result.get("success"):
+            return {"status": "success", "message_id": result.get("message_id"), "timestamp": time.time()}
+        return {"status": "failure", "error": result.get("error", "unknown"), "timestamp": time.time()}
+
+
+class SendTelegramReplyTool(ToolInterface):
+    """Reply to a specific message in a Telegram chat."""
+
+    @property
+    def name(self) -> str:
+        return "send_telegram_reply"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Reply to a specific Telegram message. Use this when responding directly "
+            "to a user's message. The reply_to_id is the message_id from the incoming message."
+        )
+
+    @property
+    def parameters_schema(self) -> Dict[str, Any]:
+        return {
+            "chat_id": "string (Telegram chat ID)",
+            "content": "string — the reply text",
+            "reply_to_id": "string — the message ID to reply to",
+        }
+
+    async def execute(
+        self, params: Dict[str, Any], context: ActionContext
+    ) -> Dict[str, Any]:
+        logger.info("Executing Telegram reply tool")
+
+        observer = getattr(context, "telegram_observer", None)
+        if not observer:
+            return {"status": "failure", "error": "Telegram observer not connected", "timestamp": time.time()}
+
+        chat_id = params.get("chat_id")
+        content = params.get("content")
+        reply_to = params.get("reply_to_id")
+
+        if not chat_id or not content or not reply_to:
+            return {"status": "failure", "error": "Missing chat_id, content, or reply_to_id", "timestamp": time.time()}
+
+        result = await observer.send_message(str(chat_id), str(content), str(reply_to))
+        if result.get("success"):
+            return {"status": "success", "message_id": result.get("message_id"), "timestamp": time.time()}
+        return {"status": "failure", "error": result.get("error", "unknown"), "timestamp": time.time()}

--- a/control_panel.py
+++ b/control_panel.py
@@ -16,8 +16,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
@@ -26,6 +25,12 @@ import uvicorn
 # Note: HistoryRecorder was consolidated into ContextManager for cleaner architecture
 from chatbot.core.orchestration import MainOrchestrator
 from chatbot.core.world_state import WorldStateManager
+from chatbot.api_server.auth import (
+    allowed_origins,
+    configured_admin_token,
+    is_admin_authorized,
+)
+from chatbot.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -68,11 +73,28 @@ app = FastAPI(title="Context Management Control Panel", version="1.0.0")
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=allowed_origins(),
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-Admin-Token"],
 )
+
+
+@app.middleware("http")
+async def require_control_panel_authentication(request, call_next):
+    if request.method != "OPTIONS" and request.url.path.startswith("/api/"):
+        if configured_admin_token() is None:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Control panel authentication is not configured"},
+            )
+        if not is_admin_authorized(request.headers):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid or missing management API token"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    return await call_next(request)
 
 @app.on_event("startup")
 async def startup_event():
@@ -189,8 +211,9 @@ async def get_context_details(channel_id: str):
             "messages": messages[-20:],  # Last 20 messages
             "system_prompt_preview": summary.get("system_prompt", "")[:500] + "..." if len(summary.get("system_prompt", "")) > 500 else summary.get("system_prompt", "")
         }
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Context not found: {str(e)}")
+    except Exception:
+        logger.exception("Could not get context %s", channel_id)
+        raise HTTPException(status_code=404, detail="Context not found")
 
 @app.post("/api/message")
 async def send_message(message: MessageRequest):
@@ -605,6 +628,13 @@ def get_control_panel_html() -> str:
     
     <script>
         let refreshInterval;
+        let adminToken;
+
+        function escapeHtml(value) {
+            const node = document.createElement('div');
+            node.textContent = String(value ?? '');
+            return node.innerHTML;
+        }
         
         async function apiCall(url, method = 'GET', body = null) {
             try {
@@ -612,6 +642,7 @@ def get_control_panel_html() -> str:
                     method,
                     headers: {
                         'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${adminToken}`,
                     }
                 };
                 
@@ -692,14 +723,14 @@ def get_control_panel_html() -> str:
                     <div class="state-change">
                         <div class="state-change-header">
                             <div>
-                                <span class="state-change-type">${change.change_type}</span>
-                                <span style="margin-left: 10px; color: #7d8590;">from ${change.source}</span>
-                                ${change.channel_id ? `<span style="margin-left: 10px; color: #58a6ff;">${change.channel_id}</span>` : ''}
+                                <span class="state-change-type">${escapeHtml(change.change_type)}</span>
+                                <span style="margin-left: 10px; color: #7d8590;">from ${escapeHtml(change.source)}</span>
+                                ${change.channel_id ? `<span style="margin-left: 10px; color: #58a6ff;">${escapeHtml(change.channel_id)}</span>` : ''}
                             </div>
-                            <div class="state-change-time">${change.formatted_time}</div>
+                            <div class="state-change-time">${escapeHtml(change.formatted_time)}</div>
                         </div>
-                        ${change.observations ? `<div style="color: #e6edf3; margin-bottom: 8px;"><strong>Observations:</strong> ${change.observations}</div>` : ''}
-                        ${change.reasoning ? `<div style="color: #e6edf3;"><strong>Reasoning:</strong> ${change.reasoning}</div>` : ''}
+                        ${change.observations ? `<div style="color: #e6edf3; margin-bottom: 8px;"><strong>Observations:</strong> ${escapeHtml(change.observations)}</div>` : ''}
+                        ${change.reasoning ? `<div style="color: #e6edf3;"><strong>Reasoning:</strong> ${escapeHtml(change.reasoning)}</div>` : ''}
                     </div>
                 `).join('');
             } catch (error) {
@@ -720,13 +751,13 @@ def get_control_panel_html() -> str:
                 container.innerHTML = contexts.map(context => `
                     <div class="context-card">
                         <div class="context-header">
-                            <div class="context-id">${context.channel_id}</div>
-                            <button class="btn btn-danger" style="padding: 5px 10px; font-size: 12px;" onclick="clearContext('${context.channel_id}')">Clear</button>
+                            <div class="context-id">${escapeHtml(context.channel_id)}</div>
+                            <button class="btn btn-danger" style="padding: 5px 10px; font-size: 12px;" data-channel-id="${escapeHtml(context.channel_id)}" onclick="clearContext(this.dataset.channelId)">Clear</button>
                         </div>
                         <div class="context-stats">
                             <span>👤 ${context.user_message_count} user messages</span>
                             <span>🤖 ${context.assistant_message_count} AI messages</span>
-                            <span>🕒 Last update: ${context.formatted_last_update}</span>
+                            <span>🕒 Last update: ${escapeHtml(context.formatted_last_update)}</span>
                         </div>
                     </div>
                 `).join('');
@@ -820,6 +851,11 @@ def get_control_panel_html() -> str:
         
         // Initialize the page
         document.addEventListener('DOMContentLoaded', function() {
+            adminToken = window.prompt('Enter the Ratichat management token');
+            if (!adminToken || new TextEncoder().encode(adminToken).length < 32) {
+                showError('A management token of at least 32 bytes is required.');
+                return;
+            }
             refreshData();
             
             // Auto-refresh every 10 seconds
@@ -851,7 +887,9 @@ def main():
     import argparse
     
     parser = argparse.ArgumentParser(description="Context Management Control Panel")
-    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
+    parser.add_argument(
+        "--host", default=settings.ADMIN_API_HOST, help="Host to bind to"
+    )
     parser.add_argument("--port", type=int, default=8001, help="Port to bind to")
     parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       - PYTHONUNBUFFERED=1
       - RATICHAT_DB_PATH=/app/data/ratichat.db
       - ARWEAVE_INTERNAL_UPLOADER_SERVICE_URL=http://arweave-service:8001
+      # Container networking requires a non-loopback bind. API authentication
+      # remains mandatory through ADMIN_API_TOKEN from .env.
+      - ADMIN_API_HOST=0.0.0.0
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
@@ -60,6 +63,7 @@ services:
       - "8001:8001"  # Expose for testing and direct access
     environment:
       - ARWEAVE_WALLET_PATH=/data/arweave_wallet.json
+      - ARWEAVE_SERVICE_API_KEY=${ARWEAVE_UPLOADER_API_KEY:?required}
       - PYTHONUNBUFFERED=1
     volumes:
       # Mount the wallet file directly from host data directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ markdown
 ollama
 httpx # Added for asynchronous HTTP requests
 colorlog # Added for colorful logging
+google-genai
 
 # Testing dependencies
 pytest>=7.0.0

--- a/setup_server.py
+++ b/setup_server.py
@@ -1,11 +1,17 @@
 
 import os
 import json
-from flask import Flask, render_template_string, request, redirect, url_for
+import hmac
+import secrets
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from flask import Flask, abort, render_template_string, request
 
 app = Flask(__name__)
 
 CONFIG_PATH = '/app/data/config.json'
+SETUP_TOKEN = secrets.token_urlsafe(32)
 
 HTML_TEMPLATE = """
 <!DOCTYPE html>
@@ -29,6 +35,7 @@ HTML_TEMPLATE = """
         <h1>MatrixBot Setup</h1>
         <p>Please enter your secrets to configure the bot.</p>
         <form method="POST" action="/setup">
+            <input type="hidden" name="setup_token" value="{{ setup_token }}">
             <label for="matrix_homeserver">Matrix Homeserver URL</label>
             <input type="text" id="matrix_homeserver" name="matrix_homeserver" placeholder="e.g., https://matrix-client.matrix.org" required>
 
@@ -64,6 +71,8 @@ SUCCESS_TEMPLATE = """
     <div class="container">
         <h1>Configuration Saved!</h1>
         <p>Your configuration has been saved successfully.</p>
+        <p>Copy this one-time management token now:</p>
+        <p><code>{{ admin_token }}</code></p>
         <p>Please restart the Docker container to start the bot.</p>
         <p>You can do this by running: <code>docker-compose restart</code></p>
     </div>
@@ -73,28 +82,60 @@ SUCCESS_TEMPLATE = """
 
 @app.route('/')
 def form():
-    return render_template_string(HTML_TEMPLATE)
+    return render_template_string(HTML_TEMPLATE, setup_token=SETUP_TOKEN)
 
 @app.route('/setup', methods=['POST'])
 def setup():
+    supplied_token = request.form.get("setup_token", "")
+    if not hmac.compare_digest(supplied_token, SETUP_TOKEN):
+        abort(403)
+
+    homeserver = request.form.get("matrix_homeserver", "").strip()
+    user_id = request.form.get("matrix_user_id", "").strip()
+    matrix_password = request.form.get("matrix_password", "")
+    openrouter_key = request.form.get("openrouter_api_key", "")
+    if not homeserver.startswith("https://") or len(homeserver) > 2048:
+        abort(400, "Matrix homeserver must be a valid HTTPS URL")
+    if not user_id.startswith("@") or ":" not in user_id or len(user_id) > 255:
+        abort(400, "Invalid Matrix user ID")
+    if not matrix_password or len(matrix_password) > 4096:
+        abort(400, "Invalid Matrix password")
+    if not openrouter_key or len(openrouter_key) > 4096:
+        abort(400, "Invalid OpenRouter API key")
+
+    admin_token = secrets.token_urlsafe(32)
     config = {
-        'MATRIX_HOMESERVER': request.form['matrix_homeserver'],
-        'MATRIX_USER_ID': request.form['matrix_user_id'],
-        'MATRIX_PASSWORD': request.form['matrix_password'],
-        'OPENROUTER_API_KEY': request.form['openrouter_api_key']
+        'MATRIX_HOMESERVER': homeserver,
+        'MATRIX_USER_ID': user_id,
+        'MATRIX_PASSWORD': matrix_password,
+        'OPENROUTER_API_KEY': openrouter_key,
+        'ADMIN_API_TOKEN': admin_token,
+        'INTEGRATION_CREDENTIAL_KEY': Fernet.generate_key().decode("ascii"),
     }
 
-    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
-    with open(CONFIG_PATH, 'w') as f:
-        json.dump(config, f, indent=4)
-    
-    # Set restrictive file permissions
-    os.chmod(CONFIG_PATH, 0o600)
+    config_path = Path(CONFIG_PATH)
+    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary_path = config_path.with_suffix(".json.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(temporary_path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w") as config_file:
+            descriptor = -1
+            json.dump(config, config_file, indent=4)
+            config_file.flush()
+            os.fsync(config_file.fileno())
+        os.replace(temporary_path, config_path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
 
-    return render_template_string(SUCCESS_TEMPLATE)
+    return render_template_string(SUCCESS_TEMPLATE, admin_token=admin_token)
 
 def run_setup_server():
-    app.run(host='0.0.0.0', port=8000)
+    app.run(host=os.getenv("SETUP_SERVER_HOST", "127.0.0.1"), port=8000)
 
 if __name__ == '__main__':
     run_setup_server()

--- a/tests/test_integration_system.py
+++ b/tests/test_integration_system.py
@@ -1,144 +1,71 @@
-#!/usr/bin/env python3
-"""Test script to validate the integration system refactor."""
+"""Integration-manager lifecycle tests with no external network access."""
 
-import asyncio
-import sys
-import os
+from typing import Any, Dict
+
 import pytest
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from chatbot.core.integration_manager import IntegrationManager
 from chatbot.core.world_state.manager import WorldStateManager
-from chatbot.core.history_recorder import HistoryRecorder
+from chatbot.integrations.base import Integration
+
+
+class DummyIntegration(Integration):
+    def __init__(
+        self,
+        integration_id: str,
+        display_name: str,
+        config: Dict[str, Any],
+    ):
+        super().__init__(integration_id, display_name, config)
+        self.connected = False
+
+    @property
+    def integration_type(self) -> str:
+        return "dummy"
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def disconnect(self) -> None:
+        self.connected = False
+
+    async def get_status(self) -> Dict[str, Any]:
+        return {
+            "integration_id": self.integration_id,
+            "is_connected": self.connected,
+        }
+
+    async def test_connection(self) -> bool:
+        return True
 
 
 @pytest.mark.asyncio
-async def test_integration_system():
-    """Test the integration system functionality."""
-    print("Testing Integration System...")
-    
-    # Use a clean test database for each run
-    test_db_path = "test_integration_system.db"
-    
-    # Remove existing test database
-    import os
-    if os.path.exists(test_db_path):
-        os.remove(test_db_path)
-    
-    # Initialize history recorder (which handles DB)
-    history_recorder = HistoryRecorder(test_db_path)
-    await history_recorder.initialize()
-    print("✓ History Recorder initialized")
-    
-    # Initialize world state manager
-    world_state_manager = WorldStateManager()
-    print("✓ World State Manager initialized")
-    
-    # Initialize integration manager
-    integration_manager = IntegrationManager(test_db_path, world_state_manager=world_state_manager)
-    await integration_manager.initialize()
-    print("✓ Integration Manager initialized")
-    
-    # Test available integration types
-    available_types = integration_manager.get_available_integration_types()
-    print(f"✓ Available integration types: {available_types}")
-    
-    # Test adding a Matrix integration
-    try:
-        matrix_config = {
-            "name": "test_matrix",
-            "integration_type": "matrix",
-            "config": {
-                "test_mode": True  # Prevent actual network connections
-            },
-            "credentials": {
-                "homeserver": "https://matrix.org",
-                "user_id": "@test:matrix.org",
-                "password": "test_password"
-            }
-        }
-        
-        await integration_manager.add_integration(
-            integration_type=matrix_config["integration_type"],
-            display_name=matrix_config["name"],
-            config=matrix_config["config"],
-            credentials=matrix_config["credentials"]
-        )
-        print("✓ Matrix integration added successfully")
-        
-        # List integrations
-        integrations = await integration_manager.list_integrations()
-        print(f"✓ Listed integrations: {len(integrations)} found")
-        
-        # Test getting integration status
-        for integration_info in integrations:
-            integration_id = integration_info['integration_id']
-            status = await integration_manager.get_integration_status(integration_id)
-            print(f"✓ Integration {integration_info['display_name']} status: {status['is_connected']}")
-        
-    except Exception as e:
-        print(f"✗ Error testing Matrix integration: {e}")
-        import traceback
-        traceback.print_exc()
-    
-    # Test adding a Farcaster integration
-    try:
-        farcaster_config = {
-            "name": "test_farcaster",
-            "integration_type": "farcaster",
-            "config": {
-                "test_mode": True  # Prevent actual network connections
-            },
-            "credentials": {
-                "api_key": "test_api_key_12345",
-                "signer_uuid": "test-signer-uuid",
-                "bot_fid": "123456"
-            }
-        }
-        
-        await integration_manager.add_integration(
-            integration_type=farcaster_config["integration_type"],
-            display_name=farcaster_config["name"],
-            config=farcaster_config["config"],
-            credentials=farcaster_config["credentials"]
-        )
-        print("✓ Farcaster integration added successfully")
-        
-    except Exception as e:
-        print(f"✗ Error testing Farcaster integration: {e}")
-        import traceback
-        traceback.print_exc()
-    
-    # Test connecting all integrations
-    try:
-        await integration_manager.connect_all()
-        print("✓ All integrations connected")
-    except Exception as e:
-        print(f"✗ Error connecting integrations: {e}")
-        import traceback
-        traceback.print_exc()
-    
-    # Test getting observers
-    try:
-        observers = integration_manager.get_observers()
-        print(f"✓ Retrieved {len(observers)} observers")
-        for observer in observers:
-            status = await observer.get_status()
-            print(f"  - {observer.__class__.__name__}: connected={status.get('is_connected', False)}")
-    except Exception as e:
-        print(f"✗ Error getting observers: {e}")
-        import traceback
-        traceback.print_exc()
-    
-    print("Integration system test completed!")
-    
-    # Cleanup test database
-    if os.path.exists(test_db_path):
-        os.remove(test_db_path)
-    
-    # Test passes if we reach this point
-    assert True
+async def test_integration_system_lifecycle() -> None:
+    manager = IntegrationManager(
+        ":memory:", world_state_manager=WorldStateManager()
+    )
+    await manager.initialize()
+    manager.integration_types["dummy"] = DummyIntegration
 
+    try:
+        integration_id = await manager.add_integration(
+            integration_type="dummy",
+            display_name="Test integration",
+            config={},
+            credentials={"token": "not-a-real-secret"},
+        )
 
-if __name__ == "__main__":
-    asyncio.run(test_integration_system())
+        configured = await manager.list_integrations()
+        assert [item["integration_id"] for item in configured] == [integration_id]
+
+        assert await manager.connect_integration(integration_id)
+        assert (await manager.get_integration_status(integration_id))[
+            "is_connected"
+        ]
+
+        assert await manager.remove_integration(integration_id)
+        assert await manager.get_integration_status(integration_id) is None
+        assert manager.get_observers() == []
+    finally:
+        await manager.disconnect_all()
+        await manager.cleanup()

--- a/tests/test_matrix_arweave_integration.py
+++ b/tests/test_matrix_arweave_integration.py
@@ -28,7 +28,7 @@ class TestMatrixArweaveIntegration:
     @pytest.fixture
     def mock_arweave_client(self):
         """Create a mock Arweave client."""
-        mock_client = AsyncMock()
+        mock_client = MagicMock()
         mock_client.upload_data = AsyncMock(return_value="test_tx_id")
         mock_client.get_arweave_url.return_value = "https://arweave.net/test_tx_id"
         return mock_client
@@ -37,7 +37,8 @@ class TestMatrixArweaveIntegration:
     def matrix_observer(self, mock_world_state, mock_arweave_client):
         """Create a Matrix observer with mocked dependencies."""
         observer = MatrixObserver(mock_world_state, mock_arweave_client)
-        observer.client = AsyncMock()
+        observer.client = MagicMock()
+        observer.client.download = AsyncMock()
         observer.user_id = "@testbot:example.com"  # Set bot user ID different from test message sender
         return observer
 

--- a/tests/test_media_action_tracking.py
+++ b/tests/test_media_action_tracking.py
@@ -91,7 +91,7 @@ class TestMediaActionTracking:
         mock_ctx.arweave_service = AsyncMock()
         # upload_image_data is called once for the image
         mock_ctx.arweave_service.upload_image_data = AsyncMock(return_value="ar://mocked_image_arweave_url")
-        mock_ctx.arweave_service.is_configured = AsyncMock(return_value=True)
+        mock_ctx.arweave_service.is_configured = MagicMock(return_value=True)
 
         # Simulate settings required by GenerateImageTool
         with patch("chatbot.tools.media_generation_tools.settings") as mock_settings:

--- a/tests/test_media_gallery_integration.py
+++ b/tests/test_media_gallery_integration.py
@@ -30,17 +30,19 @@ class TestMediaGalleryIntegration:
         context = MagicMock(spec=ActionContext)
         
         # Mock arweave service
-        context.arweave_service = AsyncMock()
+        context.arweave_service = MagicMock()
         context.arweave_service.is_configured.return_value = True
-        context.arweave_service.upload_image_data.return_value = "https://arweave.net/test-media-id"
+        context.arweave_service.upload_image_data = AsyncMock(
+            return_value="https://arweave.net/test-media-id"
+        )
         
         # Mock world state manager
         context.world_state_manager = MagicMock()
         context.world_state_manager.record_generated_media = MagicMock()
         
         # Mock matrix observer
-        context.matrix_observer = AsyncMock()
-        context.matrix_observer.client = AsyncMock()
+        context.matrix_observer = MagicMock()
+        context.matrix_observer.client = MagicMock()
         
         return context
 
@@ -53,8 +55,10 @@ class TestMediaGalleryIntegration:
         
         try:
             with patch('chatbot.tools.media_generation_tools.SendMatrixImageTool') as mock_tool_class:
-                mock_tool_instance = AsyncMock()
-                mock_tool_instance.execute.return_value = {"status": "success"}
+                mock_tool_instance = MagicMock()
+                mock_tool_instance.execute = AsyncMock(
+                    return_value={"status": "success"}
+                )
                 mock_tool_class.return_value = mock_tool_instance
                 
                 # Execute
@@ -112,8 +116,10 @@ class TestMediaGalleryIntegration:
         
         try:
             with patch('chatbot.tools.media_generation_tools.SendMatrixImageTool') as mock_tool_class:
-                mock_tool_instance = AsyncMock()
-                mock_tool_instance.execute.return_value = {"status": "error", "error": "Failed to send"}
+                mock_tool_instance = MagicMock()
+                mock_tool_instance.execute = AsyncMock(
+                    return_value={"status": "error", "error": "Failed to send"}
+                )
                 mock_tool_class.return_value = mock_tool_instance
                 
                 with caplog.at_level(logging.WARNING):
@@ -144,8 +150,10 @@ class TestMediaGalleryIntegration:
                 mock_auto_post.return_value = None
                 
                 with patch('chatbot.tools.media_generation_tools.GoogleAIMediaClient') as mock_client_class:
-                    mock_client = AsyncMock()
-                    mock_client.generate_image_gemini.return_value = b"fake_image_data"
+                    mock_client = MagicMock()
+                    mock_client.generate_image_gemini = AsyncMock(
+                        return_value=b"fake_image_data"
+                    )
                     mock_client_class.return_value = mock_client
                     
                     # Configure settings for Google AI
@@ -190,8 +198,9 @@ class TestMediaGalleryIntegration:
             orchestrator = MainOrchestrator()
             
             # Mock matrix observer and client
-            mock_matrix_observer = AsyncMock()
-            mock_client = AsyncMock()
+            mock_matrix_observer = MagicMock()
+            mock_client = MagicMock()
+            mock_client.room_create = AsyncMock()
             mock_matrix_observer.client = mock_client
             
             # Create action context manually since orchestrator hasn't started

--- a/tests/test_proactive_system.py
+++ b/tests/test_proactive_system.py
@@ -31,7 +31,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 
-class TestProactiveSystem:
+class ProactiveSystemHarness:
     """Comprehensive test suite for the proactive conversation system."""
     
     def __init__(self):
@@ -489,7 +489,7 @@ async def run_comprehensive_tests():
     logger.info("Starting comprehensive proactive conversation system tests...")
     
     # Create test instance
-    test_suite = TestProactiveSystem()
+    test_suite = ProactiveSystemHarness()
     
     try:
         # Setup test environment

--- a/tests/test_security_boundaries.py
+++ b/tests/test_security_boundaries.py
@@ -1,0 +1,218 @@
+"""Regression tests for externally reachable security boundaries."""
+
+import json
+import base64
+import asyncio
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from chatbot.api_server.auth import is_admin_authorized
+from chatbot.config import settings
+from chatbot.core.integration_manager import IntegrationManager
+from chatbot.integrations.telegram.operator_queue import OperatorQueueBridge
+from chatbot.integrations.telegram.observer import (
+    MessageRateLimiter,
+    TelegramObserver,
+    parse_id_allowlist,
+)
+
+
+class TelegramBoundaryTests(unittest.TestCase):
+    def test_allowlist_is_exact_and_fails_closed(self):
+        self.assertEqual(parse_id_allowlist("123, -456,123"), {"123", "-456"})
+        self.assertNotIn("12", parse_id_allowlist("123"))
+
+        previous = (
+            settings.TELEGRAM_BOT_TOKEN,
+            settings.TELEGRAM_ALLOWED_CHAT_IDS,
+            settings.TELEGRAM_ALLOWED_SENDER_IDS,
+        )
+        try:
+            settings.TELEGRAM_BOT_TOKEN = "token"
+            settings.TELEGRAM_ALLOWED_CHAT_IDS = "123"
+            settings.TELEGRAM_ALLOWED_SENDER_IDS = ""
+            self.assertFalse(TelegramObserver().enabled)
+        finally:
+            (
+                settings.TELEGRAM_BOT_TOKEN,
+                settings.TELEGRAM_ALLOWED_CHAT_IDS,
+                settings.TELEGRAM_ALLOWED_SENDER_IDS,
+            ) = previous
+
+    def test_rate_limit_uses_a_sliding_window(self):
+        limiter = MessageRateLimiter(2)
+        self.assertTrue(limiter.allow("sender", now=10))
+        self.assertTrue(limiter.allow("sender", now=20))
+        self.assertFalse(limiter.allow("sender", now=30))
+        self.assertTrue(limiter.allow("sender", now=71))
+
+    def test_only_exactly_authorized_messages_reach_the_operator_queue(self):
+        previous = (
+            settings.TELEGRAM_BOT_TOKEN,
+            settings.TELEGRAM_ALLOWED_CHAT_IDS,
+            settings.TELEGRAM_ALLOWED_SENDER_IDS,
+        )
+        try:
+            settings.TELEGRAM_BOT_TOKEN = "token"
+            settings.TELEGRAM_ALLOWED_CHAT_IDS = "123"
+            settings.TELEGRAM_ALLOWED_SENDER_IDS = "42"
+            observer = TelegramObserver()
+            observer.operator_queue_bridge = AsyncMock()
+
+            asyncio.run(
+                observer._handle_message(
+                    {
+                        "message_id": 7,
+                        "chat": {"id": 123},
+                        "from": {"id": 42},
+                        "text": "review this",
+                    }
+                )
+            )
+            observer.operator_queue_bridge.handle_message.assert_awaited_once_with(
+                "123", "7", "42", "review this"
+            )
+
+            observer.operator_queue_bridge.reset_mock()
+            asyncio.run(
+                observer._handle_message(
+                    {
+                        "message_id": 8,
+                        "chat": {"id": 1234},
+                        "from": {"id": 42},
+                        "text": "do not queue this",
+                    }
+                )
+            )
+            observer.operator_queue_bridge.handle_message.assert_not_awaited()
+        finally:
+            (
+                settings.TELEGRAM_BOT_TOKEN,
+                settings.TELEGRAM_ALLOWED_CHAT_IDS,
+                settings.TELEGRAM_ALLOWED_SENDER_IDS,
+            ) = previous
+
+
+class OperatorQueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_is_local_bounded_and_owner_only(self):
+        old_path = settings.TELEGRAM_OPERATOR_QUEUE_PATH
+        old_limit = settings.TELEGRAM_OPERATOR_QUEUE_MAX_BYTES
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                queue_path = Path(directory) / "operator.jsonl"
+                settings.TELEGRAM_OPERATOR_QUEUE_PATH = str(queue_path)
+                settings.TELEGRAM_OPERATOR_QUEUE_MAX_BYTES = 1024
+                observer = AsyncMock()
+                observer.send_message.return_value = {"success": True}
+                bridge = OperatorQueueBridge(observer)
+
+                await bridge.start()
+                await bridge.handle_message("123", "7", "42", "review this")
+                await bridge.handle_message("123", "7", "42", "review this")
+                bridge.max_queue_bytes = queue_path.stat().st_size
+                await bridge.handle_message("123", "8", "42", "another")
+                await bridge.stop()
+
+                entries = queue_path.read_text().splitlines()
+                self.assertEqual(len(entries), 1)
+                entry = json.loads(entries[0])
+                self.assertEqual(entry["sender_id"], "42")
+                self.assertEqual(entry["text"], "review this")
+                self.assertEqual(stat.S_IMODE(queue_path.stat().st_mode), 0o600)
+                observer.send_message.assert_awaited_with(
+                    "123",
+                    "Operator queue is full. Try again later.",
+                    "8",
+                )
+        finally:
+            settings.TELEGRAM_OPERATOR_QUEUE_PATH = old_path
+            settings.TELEGRAM_OPERATOR_QUEUE_MAX_BYTES = old_limit
+
+
+class AdminAuthenticationTests(unittest.TestCase):
+    def test_admin_token_is_required_compared_exactly_and_minimum_length(self):
+        old_token = settings.ADMIN_API_TOKEN
+        try:
+            settings.ADMIN_API_TOKEN = None
+            self.assertFalse(is_admin_authorized({}))
+            settings.ADMIN_API_TOKEN = "short"
+            self.assertFalse(is_admin_authorized({"x-admin-token": "short"}))
+
+            token = "a" * 32
+            settings.ADMIN_API_TOKEN = token
+            self.assertFalse(is_admin_authorized({"authorization": f"Bearer {token}x"}))
+            self.assertTrue(is_admin_authorized({"authorization": f"Bearer {token}"}))
+            self.assertTrue(is_admin_authorized({"x-admin-token": token}))
+            encoded = base64.urlsafe_b64encode(token.encode()).decode().rstrip("=")
+            self.assertTrue(
+                is_admin_authorized(
+                    {
+                        "sec-websocket-protocol": (
+                            f"ratichat-admin, auth.{encoded}"
+                        )
+                    }
+                )
+            )
+        finally:
+            settings.ADMIN_API_TOKEN = old_token
+
+
+class IntegrationDeletionTests(unittest.IsolatedAsyncioTestCase):
+    def test_production_requires_a_stable_credential_key(self):
+        old_environment = settings.CHATBOT_ENV
+        try:
+            settings.CHATBOT_ENV = "production"
+            with self.assertRaisesRegex(
+                ValueError, "INTEGRATION_CREDENTIAL_KEY"
+            ):
+                IntegrationManager(":memory:")
+        finally:
+            settings.CHATBOT_ENV = old_environment
+
+    async def test_remove_integration_deletes_credentials_and_configuration(self):
+        manager = IntegrationManager(":memory:")
+        await manager.initialize()
+        try:
+            now = 1.0
+            await manager._persistent_db.execute(
+                """
+                INSERT INTO integrations
+                    (id, user_id, integration_type, display_name, is_active,
+                     config, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("integration-1", None, "dummy", "Dummy", True, "{}", now, now),
+            )
+            await manager._persistent_db.execute(
+                """
+                INSERT INTO credentials
+                    (id, integration_id, credential_key,
+                     credential_value_encrypted, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    "credential-1",
+                    "integration-1",
+                    "token",
+                    manager.cipher.encrypt(b"not-a-real-secret"),
+                    now,
+                ),
+            )
+            await manager._persistent_db.commit()
+
+            self.assertTrue(await manager.remove_integration("integration-1"))
+            self.assertFalse(await manager.remove_integration("integration-1"))
+            cursor = await manager._persistent_db.execute(
+                "SELECT COUNT(*) FROM credentials WHERE integration_id = ?",
+                ("integration-1",),
+            )
+            self.assertEqual((await cursor.fetchone())[0], 0)
+        finally:
+            await manager.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-nextjs/src/api.ts
+++ b/ui-nextjs/src/api.ts
@@ -1,0 +1,35 @@
+import axios from 'axios'
+
+let adminToken: string | null = null
+
+export const apiClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+  timeout: 15_000,
+})
+
+apiClient.interceptors.request.use((config) => {
+  if (adminToken) {
+    config.headers.Authorization = `Bearer ${adminToken}`
+  }
+  return config
+})
+
+export function setAdminToken(token: string | null): void {
+  adminToken = token
+}
+
+export function getAdminWebSocketProtocols(): string[] {
+  if (!adminToken) {
+    return []
+  }
+  const bytes = new TextEncoder().encode(adminToken)
+  let binary = ''
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  const encoded = btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return ['ratichat-admin', `auth.${encoded}`]
+}

--- a/ui-nextjs/src/app/page.tsx
+++ b/ui-nextjs/src/app/page.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import SetupWizard from '@/components/SetupWizard'
 import Dashboard from '@/components/Dashboard'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
-import { apiClient } from '@/lib/api'
-import { SystemInfo, SystemStatus } from '@/types'
+import { apiClient, setAdminToken } from '@/api'
+import { SystemInfo } from '@/types'
 
 export default function Home() {
   const [systemInfo, setSystemInfo] = useState<SystemInfo>({ status: 'LOADING' })
   const [error, setError] = useState<string | null>(null)
+  const [tokenInput, setTokenInput] = useState('')
+  const [authenticated, setAuthenticated] = useState(false)
+  const [authenticating, setAuthenticating] = useState(false)
 
   const checkSystemStatus = async () => {
     try {
@@ -17,37 +20,87 @@ export default function Home() {
       const systemData = response.data as SystemInfo
       setSystemInfo(systemData)
       setError(null)
+      return true
     } catch (err: any) {
       console.error('Failed to fetch system status:', err)
       setError(err.response?.data?.detail || 'Failed to connect to the backend')
       setSystemInfo({ status: 'ERROR' })
+      return false
     }
   }
 
   useEffect(() => {
-    checkSystemStatus()
+    if (!authenticated) return
     // Poll status every 30 seconds
     const interval = setInterval(checkSystemStatus, 30000)
     return () => clearInterval(interval)
-  }, [])
+  }, [authenticated])
+
+  const handleAuthenticate = async (event: FormEvent) => {
+    event.preventDefault()
+    if (new TextEncoder().encode(tokenInput).length < 32) {
+      setError('The management token must be at least 32 bytes.')
+      return
+    }
+
+    setAuthenticating(true)
+    setAdminToken(tokenInput)
+    const accepted = await checkSystemStatus()
+    if (accepted) {
+      setAuthenticated(true)
+      setTokenInput('')
+    } else {
+      setAdminToken(null)
+    }
+    setAuthenticating(false)
+  }
 
   const handleSetupComplete = () => {
     // Refresh system status after setup completion
     checkSystemStatus()
   }
 
+  if (!authenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <form
+          onSubmit={handleAuthenticate}
+          className="w-full max-w-md rounded-lg bg-white p-8 shadow"
+        >
+          <h1 className="text-2xl font-semibold text-gray-900">
+            Ratichat administration
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Enter the local management token. It is kept only in this page&apos;s
+            memory and is cleared on reload.
+          </p>
+          <label className="mt-6 block text-sm font-medium text-gray-700">
+            Management token
+          </label>
+          <input
+            type="password"
+            autoComplete="off"
+            value={tokenInput}
+            onChange={(event) => setTokenInput(event.target.value)}
+            className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2"
+          />
+          {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={authenticating}
+            className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-white disabled:bg-gray-400"
+          >
+            {authenticating ? 'Authenticating…' : 'Authenticate'}
+          </button>
+        </form>
+      </div>
+    )
+  }
+
   if (systemInfo.status === 'LOADING') {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <LoadingSpinner size="large" />
-          <h2 className="mt-4 text-xl font-medium text-gray-700">
-            Connecting to Ratichat...
-          </h2>
-          <p className="mt-2 text-gray-500">
-            Initializing the administrative interface
-          </p>
-        </div>
+        <LoadingSpinner size="large" />
       </div>
     )
   }

--- a/ui-nextjs/src/components/ConfigurationEditor.tsx
+++ b/ui-nextjs/src/components/ConfigurationEditor.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import { Configuration } from '@/types'
 
 export default function ConfigurationEditor() {

--- a/ui-nextjs/src/components/Dashboard.tsx
+++ b/ui-nextjs/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import LogViewer from '@/components/LogViewer'
 import StatusPanel from '@/components/StatusPanel'
 import ToolManager from '@/components/ToolManager'

--- a/ui-nextjs/src/components/LogViewer.tsx
+++ b/ui-nextjs/src/components/LogViewer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
+import { getAdminWebSocketProtocols } from '@/api'
 
 interface LogEntry {
   timestamp: string
@@ -21,7 +22,7 @@ export default function LogViewer() {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
     const wsUrl = apiUrl.replace(/^https?/, apiUrl.startsWith('https') ? 'wss' : 'ws') + '/ws/logs'
     
-    const websocket = new WebSocket(wsUrl)
+    const websocket = new WebSocket(wsUrl, getAdminWebSocketProtocols())
 
     websocket.onopen = () => {
       setIsConnected(true)

--- a/ui-nextjs/src/components/SetupWizard.tsx
+++ b/ui-nextjs/src/components/SetupWizard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useRef } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import { SetupStep } from '@/types'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 

--- a/ui-nextjs/src/components/StatusPanel.tsx
+++ b/ui-nextjs/src/components/StatusPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import { SystemInfo, DashboardProps } from '@/types'
 

--- a/ui-nextjs/src/components/ToolManager.tsx
+++ b/ui-nextjs/src/components/ToolManager.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import { Tool, ToolsResponse } from '@/types'
 

--- a/ui-nextjs/src/components/WorldStateExplorer.tsx
+++ b/ui-nextjs/src/components/WorldStateExplorer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { apiClient } from '@/lib/api'
+import { apiClient } from '@/api'
 import { WorldState } from '@/types'
 
 export default function WorldStateExplorer() {


### PR DESCRIPTION
Fixes #1

## What changed

- removes the Telegram remote-command execution path and replaces it with exact allowlists and a bounded local operator queue
- adds authentication and safer CORS/WebSocket handling to management APIs
- enforces uploader limits, webhook HMAC validation, and fail-closed credential handling
- prevents internal error leakage and corrects API lifecycle behavior
- wires UI authentication consistently and adds security regression coverage

## Root cause and impact

External control surfaces trusted caller input and deployment configuration too broadly. That exposed command execution, unauthenticated management actions, replay or spoofing risks, and credential-lifecycle failures.

The repaired boundaries authenticate privileged operations, constrain inputs and queues, and fail closed without exposing internal details.

## Verification

- `python -m pytest` — 385 passed, 1 skipped
- `python -m compileall -q chatbot arweave-service arweave_uploader_service tests`
- UI TypeScript parsed and bundled with Bun
- `docker compose config --no-env-resolution --no-interpolate --quiet`
- staged diff check

All commands exited zero at commit `6f8743f2881244cf273c92b95e0c0197b823d462`. The repository policy gate passed with no violations or warnings.